### PR TITLE
ExDocs wasn't rendering this table correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ Listeners have special support for GenServers.  By default a listener will provi
 
 Given a listener with the tag `:tag` the messages from a GenServer are formatted as follows.
 
-| Client Code                   | Message to Test Process                    |
-|:------------------------------|:-------------------------------------------|
-| GenServer.call(pid, :message) | {:tag, {GenServer, :call, :message, from}} |
-|  # if capture_replies = true  | {:tag, {GenServer, :reply, result, from}}  |
-| GenServer.cast(pid, :message) | {:tag, {GenServer, :cast, :message}}       |
+| Client Code                   | Message to Test Process                      |
+|:------------------------------|:---------------------------------------------|
+| GenServer.call(pid, :message) | `{:tag, {GenServer, :call, :message, from}}` |
+|  # if capture_replies = true  | `{:tag, {GenServer, :reply, result, from}}`  |
+| GenServer.cast(pid, :message) | `{:tag, {GenServer, :cast, :message}}`       |
 
 During a `GenServer.call/3` the listener sits between the client and the server and reports back information to the test process.
 

--- a/pages/README.md
+++ b/pages/README.md
@@ -298,11 +298,11 @@ Listeners have special support for GenServers.  By default a listener will provi
 
 Given a listener with the tag `:tag` the messages from a GenServer are formatted as follows.
 
-| Client Code                   | Message to Test Process                    |
-|:------------------------------|:-------------------------------------------|
-| GenServer.call(pid, :message) | {:tag, {GenServer, :call, :message, from}} |
-|  # if capture_replies = true  | {:tag, {GenServer, :reply, result, from}}  |
-| GenServer.cast(pid, :message) | {:tag, {GenServer, :cast, :message}}       |
+| Client Code                   | Message to Test Process                      |
+|:------------------------------|:---------------------------------------------|
+| GenServer.call(pid, :message) | `{:tag, {GenServer, :call, :message, from}}` |
+|  # if capture_replies = true  | `{:tag, {GenServer, :reply, result, from}}`  |
+| GenServer.cast(pid, :message) | `{:tag, {GenServer, :cast, :message}}`       |
 
 During a `GenServer.call/3` the listener sits between the client and the server and reports back information to the test process.
 

--- a/pages/templates/README.eex
+++ b/pages/templates/README.eex
@@ -298,11 +298,11 @@ Listeners have special support for GenServers.  By default a listener will provi
 
 Given a listener with the tag `:tag` the messages from a GenServer are formatted as follows.
 
-| Client Code                   | Message to Test Process                    |
-|:------------------------------|:-------------------------------------------|
-| GenServer.call(pid, :message) | {:tag, {GenServer, :call, :message, from}} |
-|  # if capture_replies = true  | {:tag, {GenServer, :reply, result, from}}  |
-| GenServer.cast(pid, :message) | {:tag, {GenServer, :cast, :message}}       |
+| Client Code                   | Message to Test Process                      |
+|:------------------------------|:---------------------------------------------|
+| GenServer.call(pid, :message) | `{:tag, {GenServer, :call, :message, from}}` |
+|  # if capture_replies = true  | `{:tag, {GenServer, :reply, result, from}}`  |
+| GenServer.cast(pid, :message) | `{:tag, {GenServer, :cast, :message}}`       |
 
 During a `GenServer.call/3` the listener sits between the client and the server and reports back information to the test process.
 


### PR DESCRIPTION
For some reason the `Message to Test Process` column would stop after
the opening brace, maybe `:` is a special character in the exdocs
markdown processor.