### PR TITLE
Call count assertions.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,17 +2,29 @@
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: [
+    assert_any_call: 1,
     assert_any_call: 2,
     assert_called: 1,
+    assert_called: 2,
+    assert_called_once: 1,
+    refute_any_call: 1,
     refute_any_call: 2,
-    refute_called: 1
+    refute_called: 1,
+    refute_called: 2,
+    refute_called_once: 1
   ],
   exports: [
     locals_without_parens: [
+      assert_any_call: 1,
       assert_any_call: 2,
       assert_called: 1,
+      assert_called: 2,
+      assert_called_once: 1,
+      refute_any_call: 1,
       refute_any_call: 2,
-      refute_called: 1
+      refute_called: 1,
+      refute_called: 2,
+      refute_called_once: 1
     ]
   ]
 ]

--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -1,0 +1,387 @@
+defmodule Patch.Assertions do
+  alias Patch.MissingCall
+  alias Patch.Mock
+  alias Patch.UnexpectedCall
+
+  @doc """
+  Asserts that the given module and function has been called with any arity.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Patch.Assertions.assert_any_call(Example, :function)   # fails
+
+  Example.function(1, 2, 3)
+
+  Patch.Asertions.assert_any_call(Example, :function)   # passes
+  ```
+
+  There is a convenience delegate in the Developer Interface, `Patch.assert_any_call/2` which
+  should be preferred over calling this function directly.
+  """
+  @spec assert_any_call(module :: module(), function :: atom()) :: nil
+  def assert_any_call(module, function) do
+    unless Mock.called?(module, function) do
+      message = """
+      \n
+      Expected any call to the following function:
+
+        #{inspect(module)}.#{to_string(function)}
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching_any(module, function)}
+      """
+
+      raise MissingCall, message: message
+    end
+  end
+
+  @doc """
+  Given a call will assert that a matching call was observed by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.assert_called(Example, :function, [1, 2, 3])   # passes
+  Patch.Assertions.assert_called(Example, :function, [1, :_, 3])  # passes
+  Patch.Assertions.assert_called(Example, :function, [4, 5, 6])   # fails
+  Patch.Assertions.assert_called(Example, :function, [4, :_, 6])  # fails
+  ```
+  There is a convenience macro in the Developer Interface, `Patch.assert_called/1` which should be
+  preferred over calling this function directly.
+  """
+  @spec assert_called(module :: module(), function :: atom(), arguments :: [term()]) :: nil
+  def assert_called(module, function, arguments) do
+    unless Patch.Mock.called?(module, function, arguments) do
+      message = """
+      \n
+      Expected but did not receive the following call:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise MissingCall, message: message
+    end
+  end
+
+  @doc """
+  Given a call will assert that a matching call was observed exactly the number of times provided
+  by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.assert_called(Example, :function, [1, 2, 3], 1)   # passes
+  Patch.Assertions.assert_called(Example, :function, [1, :_, 3], 1)  # passes
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.assert_called(Example, :function, [1, 2, 3], 2)   # passes
+  Patch.Assertions.assert_called(Example, :function, [1, :_, 3], 2)  # passes
+  ```
+
+  There is a convenience macro in the Developer Interface, `Patch.assert_called/2` which
+  should be preferred over calling this function directly.
+  """
+  @spec assert_called(module :: module(), function :: atom(), arguments :: [term()], count :: non_neg_integer()) :: nil
+  def assert_called(module, function, arguments, count) do
+    call_count = Patch.Mock.call_count(module, function, arguments)
+
+    unless call_count == count do
+      exception =
+        if call_count < count do
+          MissingCall
+        else
+          UnexpectedCall
+        end
+
+      message = """
+      \n
+      Expected #{count} of the following calls, but found #{call_count}:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise exception, message
+    end
+  end
+
+  @doc """
+  Given a call will assert that a matching call was observed exactly once by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.assert_called_once(Example, :function, [1, 2, 3])   # passes
+  Patch.Assertions.assert_called_once(Example, :function, [1, :_, 3])  # passes
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.assert_called_once(Example, :function, [1, 2, 3])   # fails
+  Patch.Assertions.assert_called_once(Example, :function, [1, :_, 3])  # fails
+  ```
+
+  There is a convenience macro in the Developer Interface, `Patch.assert_called_once/1` which
+  should be preferred over calling this function directly.
+  """
+  @spec assert_called_once(module :: module(), function :: atom(), arguments :: [term()]) :: nil
+  def assert_called_once(module, function, arguments) do
+    call_count = Patch.Mock.call_count(module, function, arguments)
+
+    unless call_count == 1 do
+      exception =
+        if call_count == 0 do
+          MissingCall
+        else
+          UnexpectedCall
+        end
+
+      message = """
+      \n
+      Expected the following call to occur exactly once, but call occurred #{call_count} times:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise exception, message
+    end
+  end
+
+  @doc """
+  Refutes that the given module and function has been called with any arity.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Patch.Assertions.refute_any_call(Example, :function)   # passes
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_any_call(Example, :function)   # fails
+  ```
+
+  There is a convenience delegate in the Developer Interface, `Patch.refute_any_call/2` which
+  should be preferred over calling this function directly.
+  """
+  @spec refute_any_call(module :: module(), function :: atom()) :: nil
+  def refute_any_call(module, function) do
+    if Mock.called?(module, function) do
+      message = """
+      \n
+      Unexpected call received, expected no calls:
+
+        #{inspect(module)}.#{to_string(function)}
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching_any(module, function)}
+      """
+
+      raise UnexpectedCall, message: message
+    end
+  end
+
+  @doc """
+  Given a call will refute that a matching call was observed by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_called(Example, :function, [4, 5, 6])   # passes
+  Patch.Assertions.refute_called(Example, :function, [4, :_, 6])  # passes
+  Patch.Assertions.refute_called(Example, :function, [1, 2, 3])   # fails
+  Patch.Assertions.refute_called(Example, :function, [1, :_, 3])  # passes
+  ```
+
+  There is a convenience macro in the Developer Interface, `Patch.refute_called/1` which should be
+  preferred over calling this function directly.
+  """
+  @spec refute_called(module :: module(), function :: atom(), arguments :: [term()]) :: nil
+  def refute_called(module, function, arguments) do
+    if Patch.Mock.called?(module, function, arguments) do
+      message = """
+      \n
+      Unexpected call received:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise UnexpectedCall, message: message
+    end
+  end
+
+  @doc """
+  Given a call will refute that a matching call was observed exactly the number of times provided
+  by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_called(Example, :function, [1, 2, 3], 2)   # passes
+  Patch.Assertions.refute_called(Example, :function, [1, :_, 3], 2)  # passes
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_called(Example, :function, [1, 2, 3], 1)   # passes
+  Patch.Assertions.refute_called(Example, :function, [1, :_, 3], 1)  # passes
+  ```
+
+  There is a convenience macro in the Developer Interface, `Patch.refute_called/2` which
+  should be preferred over calling this function directly.
+  """
+  @spec refute_called(module :: module(), function :: atom(), arguments :: [term()], count :: non_neg_integer()) :: nil
+  def refute_called(module, function, arguments, count) do
+    call_count = Patch.Mock.call_count(module, function, arguments)
+
+    if call_count == count do
+      message = """
+      \n
+      Expected any count except #{count} of the following calls, but found #{count}:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise UnexpectedCall, message
+    end
+  end
+
+  @doc """
+  Given a call will refute that a matching call was observed exactly the number of times provided
+  by the patched function.
+
+  The call can use the special sentinal `:_` as a wildcard match.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_called_once(Example, :function, [1, 2, 3], 2)   # fails
+  Patch.Assertions.refute_called_once(Example, :function, [1, :_, 3], 2)  # fails
+
+  Example.function(1, 2, 3)
+
+  Patch.Assertions.refute_called_once(Example, :function, [1, 2, 3], 1)   # passes
+  Patch.Assertions.refute_called_once(Example, :function, [1, :_, 3], 1)  # passes
+  ```
+
+  There is a convenience macro in the Developer Interface, `Patch.refute_called_once/1` which
+  should be preferred over calling this function directly.
+  """
+  @spec refute_called_once(module :: module(), function :: atom(), arguments :: [term()]) :: nil
+  def refute_called_once(module, function, arguments) do
+    call_count = Patch.Mock.call_count(module, function, arguments)
+
+    if call_count == 1 do
+      message = """
+      \n
+      Expected the following call to occur any number of times but once, but it occurred once:
+
+        #{inspect(module)}.#{to_string(function)}(#{format_arguments(arguments)})
+
+      Calls which were received (matching calls are marked with *):
+
+      #{format_calls_matching(module, function, arguments)}
+      """
+
+      raise UnexpectedCall, message
+    end
+  end
+
+  ## Private
+
+  @spec format_arguments(arguments :: [term()]) :: String.t()
+  defp format_arguments(arguments) do
+    arguments
+    |> Enum.map(&Kernel.inspect/1)
+    |> Enum.join(", ")
+  end
+
+  @spec format_calls_matching_any(module :: module(), expected_function :: atom()) :: String.t()
+  defp format_calls_matching_any(module, expected_function) do
+    module
+    |> Patch.history()
+    |> Enum.with_index(1)
+    |> Enum.map(fn {{actual_function, arguments}, i} ->
+      marker =
+        if expected_function == actual_function do
+          "* "
+        else
+          "  "
+        end
+
+      "#{marker}#{i}. #{inspect(module)}.#{actual_function}(#{format_arguments(arguments)})"
+    end)
+    |> case do
+      [] ->
+        "  [No Calls Received]"
+      calls ->
+        Enum.join(calls, "\n")
+    end
+  end
+
+  @spec format_calls_matching(module :: module(), expected_function :: atom(), expected_arguments :: [term()]) :: String.t()
+  defp format_calls_matching(module, expected_function, expected_arguments) do
+    module
+    |> Patch.history()
+    |> Enum.with_index(1)
+    |> Enum.map(fn {{actual_function, actual_arguments}, i} ->
+      marker =
+        if expected_function == actual_function and Mock.arguments_compatible?(expected_arguments, actual_arguments) do
+          "* "
+        else
+          "  "
+        end
+
+      "#{marker}#{i}. #{inspect(module)}.#{actual_function}(#{format_arguments(actual_arguments)})"
+    end)
+    |> case do
+      [] ->
+        "  [No Calls Received]"
+      calls ->
+        Enum.join(calls, "\n")
+    end
+  end
+
+end

--- a/test/support/user/assert_any_call.ex
+++ b/test/support/user/assert_any_call.ex
@@ -10,4 +10,8 @@ defmodule Patch.Test.Support.User.AssertAnyCall do
   def function_with_multiple_arities(a, b, c) do
     {:original, {a, b, c}}
   end
+
+  def other_function(a) do
+    {:other, a}
+  end
 end

--- a/test/support/user/assert_called_once.ex
+++ b/test/support/user/assert_called_once.ex
@@ -1,0 +1,5 @@
+defmodule Patch.Test.Support.User.AssertCalledOnce do
+  def example(a, b) do
+    {:original, a, b}
+  end
+end

--- a/test/support/user/refute_any_call.ex
+++ b/test/support/user/refute_any_call.ex
@@ -10,4 +10,8 @@ defmodule Patch.Test.Support.User.RefuteAnyCall do
   def function_with_multiple_arities(a, b, c) do
     {:original, {a, b, c}}
   end
+
+  def other_function(a) do
+    {:other, a}
+  end
 end

--- a/test/support/user/refute_called_once.ex
+++ b/test/support/user/refute_called_once.ex
@@ -1,0 +1,5 @@
+defmodule Patch.Test.Support.User.RefuteCalledOnce do
+  def example(a, b) do
+    {:original, a, b}
+  end
+end

--- a/test/user/assert_any_call_test.exs
+++ b/test/user/assert_any_call_test.exs
@@ -4,6 +4,105 @@ defmodule Patch.Test.User.AssertAnyCallTest do
 
   alias Patch.Test.Support.User.AssertAnyCall
 
+  describe "assert_any_call/1" do
+    test "does not raise if a patched function has a call of any arity (/1)" do
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == AssertAnyCall.function_with_multiple_arities(1)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a patched function has a call of any arity (/2)" do
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == AssertAnyCall.function_with_multiple_arities(1, 2)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a patched function has a call of any arity (/3)" do
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == AssertAnyCall.function_with_multiple_arities(1, 2, 3)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a spied module has a call of any arity (/1)" do
+      spy(AssertAnyCall)
+
+      assert {:original, 1} == AssertAnyCall.function_with_multiple_arities(1)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a spied module has a call of any arity (/2)" do
+      spy(AssertAnyCall)
+
+      assert {:original, {1, 2}} == AssertAnyCall.function_with_multiple_arities(1, 2)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a spied module has a call of any arity (/3)" do
+      spy(AssertAnyCall)
+
+      assert {:original, {1, 2, 3}} == AssertAnyCall.function_with_multiple_arities(1, 2, 3)
+
+      assert_any_call AssertAnyCall.function_with_multiple_arities
+    end
+
+    test "raises if a patched function has no calls" do
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_any_call AssertAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a spied module function has no calls" do
+      spy(AssertAnyCall)
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_any_call AssertAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises in the presence of calls to other functions" do
+      patch(AssertAnyCall, :other_function, :patched)
+
+      assert AssertAnyCall.other_function(1) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_any_call AssertAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "exception formatting" do
+      patch(AssertAnyCall, :other_function, :patched_result)
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert AssertAnyCall.other_function(1) == :patched_result
+
+      expected_message = """
+      \n
+      Expected any call to the following function:
+
+        Patch.Test.Support.User.AssertAnyCall.function_with_multiple_arities
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertAnyCall.other_function(1)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_any_call AssertAnyCall.function_with_multiple_arities
+      end
+    end
+
+  end
+
   describe "assert_any_call/2" do
     test "does not raise if a patched function has a call of any arity (/1)" do
       patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
@@ -65,6 +164,38 @@ defmodule Patch.Test.User.AssertAnyCallTest do
       spy(AssertAnyCall)
 
       assert_raise Patch.MissingCall, fn ->
+        assert_any_call AssertAnyCall, :function_with_multiple_arities
+      end
+    end
+
+    test "raises in the presence of calls to other functions" do
+      patch(AssertAnyCall, :other_function, :patched)
+
+      assert AssertAnyCall.other_function(1) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_any_call AssertAnyCall, :function_with_multiple_arities
+      end
+    end
+
+    test "exception formatting" do
+      patch(AssertAnyCall, :other_function, :patched_result)
+      patch(AssertAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert AssertAnyCall.other_function(1) == :patched_result
+
+      expected_message = """
+      \n
+      Expected any call to the following function:
+
+        Patch.Test.Support.User.AssertAnyCall.function_with_multiple_arities
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertAnyCall.other_function(1)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
         assert_any_call AssertAnyCall, :function_with_multiple_arities
       end
     end

--- a/test/user/assert_called_once_test.exs
+++ b/test/user/assert_called_once_test.exs
@@ -1,0 +1,169 @@
+defmodule Patch.Test.User.AssertCalledOnecTest do
+  use ExUnit.Case
+  use Patch
+
+  alias Patch.Test.Support.User.AssertCalledOnce
+
+  describe "assert_called_once/1" do
+    test "exact call can be asserted" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_called_once AssertCalledOnce.example(1, 2)
+    end
+
+    test "exact call mismatch raises MissingCall" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called_once AssertCalledOnce.example(3, 4)
+      end
+    end
+
+    test "exact call after multiple calls raises UnexpectedCall" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called_once AssertCalledOnce.example(1, 2)
+      end
+    end
+
+    test "partial call can be asserted" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_called_once AssertCalledOnce.example(1, :_)
+      assert_called_once AssertCalledOnce.example(:_, 2)
+    end
+
+    test "partial call mismatch raises MissingCall" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called_once AssertCalledOnce.example(3, :_)
+      end
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called_once AssertCalledOnce.example(:_, 4)
+      end
+    end
+
+    test "partial call after multiple calls raises UnexpectedCall" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+      assert AssertCalledOnce.example(1, 3) == :patched
+      assert AssertCalledOnce.example(3, 2) == :patched
+
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called_once AssertCalledOnce.example(1, :_)
+      end
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called_once AssertCalledOnce.example(:_, 2)
+      end
+    end
+
+    test "wildcard call can be asserted" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      assert_called_once AssertCalledOnce.example(:_, :_)
+    end
+
+    test "wildcard call raises MissingCall when no calls present" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called_once AssertCalledOnce.example(:_, :_)
+      end
+    end
+
+    test "wildcard call raises UnexpectedCall when multiple calls present" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+      assert AssertCalledOnce.example(3, 4) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called_once AssertCalledOnce.example(:_, :_)
+      end
+    end
+
+    test "exception formatting with no calls" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      expected_message = """
+      \n
+      Expected the following call to occur exactly once, but call occurred 0 times:
+
+        Patch.Test.Support.User.AssertCalledOnce.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+        [No Calls Received]
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called_once AssertCalledOnce.example(1, 2)
+      end
+    end
+
+    test "exception formatting with non-matching calls" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected the following call to occur exactly once, but call occurred 0 times:
+
+        Patch.Test.Support.User.AssertCalledOnce.example(3, 4)
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertCalledOnce.example(1, 2)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called_once AssertCalledOnce.example(3, 4)
+      end
+    end
+
+    test "exception formatting with wrong number of matched calls" do
+      patch(AssertCalledOnce, :example, :patched)
+
+      assert AssertCalledOnce.example(1, 2) == :patched
+      assert AssertCalledOnce.example(3, 4) == :patched
+      assert AssertCalledOnce.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected the following call to occur exactly once, but call occurred 2 times:
+
+        Patch.Test.Support.User.AssertCalledOnce.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.AssertCalledOnce.example(1, 2)
+        2. Patch.Test.Support.User.AssertCalledOnce.example(3, 4)
+      * 3. Patch.Test.Support.User.AssertCalledOnce.example(1, 2)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        assert_called_once AssertCalledOnce.example(1, 2)
+      end
+    end
+  end
+end

--- a/test/user/assert_called_test.exs
+++ b/test/user/assert_called_test.exs
@@ -61,5 +61,260 @@ defmodule Patch.Test.User.AssertCalledTest do
         assert_called AssertCalled.example(:_, :_)
       end
     end
+
+    test "exception formatting with no calls" do
+      patch(AssertCalled, :example, :patched)
+
+      expected_message = """
+      \n
+      Expected but did not receive the following call:
+
+        Patch.Test.Support.User.AssertCalled.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+        [No Calls Received]
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called AssertCalled.example(1, 2)
+      end
+    end
+
+    test "exception formatting with non-matching calls" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected but did not receive the following call:
+
+        Patch.Test.Support.User.AssertCalled.example(3, 4)
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertCalled.example(1, 2)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called AssertCalled.example(3, 4)
+      end
+    end
+  end
+
+  describe "assert_called/2" do
+    test "exact call can be asserted with literal count" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, 2), 1
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, 2), 2
+    end
+
+    test "exact call can be asserted with expression count" do
+      patch(AssertCalled, :example, :patched)
+
+      expected_count = 1
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, 2), expected_count
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, 2), expected_count + 1
+    end
+
+    test "exact call mismatch raises MissingCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(3, 4), 1
+      end
+    end
+
+    test "exact call with too high an expected count raises MissingCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(1, 2), 2
+      end
+    end
+
+    test "exact call with too low an expected count raises UnexpectedCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called AssertCalled.example(1, 2), 1
+      end
+    end
+
+    test "partial call can be asserted with literal count" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, :_), 1
+      assert_called AssertCalled.example(:_, 2), 1
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(1, :_), 2
+      assert_called AssertCalled.example(:_, 2), 2
+    end
+
+    test "partial call mismatch raises MissingCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(3, :_), 1
+      end
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(:_, 4), 1
+      end
+    end
+
+    test "partial call with too high an expected count raises MissingCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(1, :_), 2
+      end
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(:_, 2), 2
+      end
+    end
+
+    test "partial call with too low an expected count raises UnexpectedCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(1, 3) == :patched
+      assert AssertCalled.example(3, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called AssertCalled.example(1, :_), 1
+      end
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called AssertCalled.example(:_, 2), 1
+      end
+    end
+
+    test "wildcard call can be asserted" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(:_, :_), 1
+
+      assert AssertCalled.example(3, 4) == :patched
+
+      assert_called AssertCalled.example(:_, :_), 2
+    end
+
+    test "wildcard call with too high an expected count raises MissingCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_raise Patch.MissingCall, fn ->
+        assert_called AssertCalled.example(:_, :_), 2
+      end
+    end
+
+    test "wildcard call with too low an expected count raises UnexpectedCall" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(3, 4) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        assert_called AssertCalled.example(:_, :_), 1
+      end
+    end
+
+    test "exception formatting with no calls" do
+      patch(AssertCalled, :example, :patched)
+
+      expected_message = """
+      \n
+      Expected 1 of the following calls, but found 0:
+
+        Patch.Test.Support.User.AssertCalled.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+        [No Calls Received]
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called AssertCalled.example(1, 2), 1
+      end
+    end
+
+    test "exception formatting with non-matching calls" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected 1 of the following calls, but found 0:
+
+        Patch.Test.Support.User.AssertCalled.example(3, 4)
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertCalled.example(1, 2)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called AssertCalled.example(3, 4), 1
+      end
+    end
+
+    test "exception formatting with wrong number of matched calls" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(3, 4) == :patched
+      assert AssertCalled.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected 1 of the following calls, but found 2:
+
+        Patch.Test.Support.User.AssertCalled.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.AssertCalled.example(1, 2)
+        2. Patch.Test.Support.User.AssertCalled.example(3, 4)
+      * 3. Patch.Test.Support.User.AssertCalled.example(1, 2)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        assert_called AssertCalled.example(1, 2), 1
+      end
+    end
   end
 end

--- a/test/user/refute_any_call_test.exs
+++ b/test/user/refute_any_call_test.exs
@@ -4,6 +4,111 @@ defmodule Patch.Test.User.RefuteAnyCallTest do
 
   alias Patch.Test.Support.User.RefuteAnyCall
 
+  describe "refute_any_call/1" do
+    test "raises if a patched function has a call of any arity (/1)" do
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == RefuteAnyCall.function_with_multiple_arities(1)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a patched function has a call of any arity (/2)" do
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == RefuteAnyCall.function_with_multiple_arities(1, 2)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a patched function has a call of any arity (/3)" do
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert :patched_result == RefuteAnyCall.function_with_multiple_arities(1, 2, 3)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a spied module has a call of any arity (/1)" do
+      spy(RefuteAnyCall)
+
+      assert {:original, 1} == RefuteAnyCall.function_with_multiple_arities(1)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a spied module has a call of any arity (/2)" do
+      spy(RefuteAnyCall)
+
+      assert {:original, {1, 2}} == RefuteAnyCall.function_with_multiple_arities(1, 2)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "raises if a spied module has a call of any arity (/3)" do
+      spy(RefuteAnyCall)
+
+      assert {:original, {1, 2, 3}} == RefuteAnyCall.function_with_multiple_arities(1, 2, 3)
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+
+    test "does not raise if a patched function has no calls" do
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+      refute_any_call RefuteAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if a spied module function has no calls" do
+      spy(RefuteAnyCall)
+      refute_any_call RefuteAnyCall.function_with_multiple_arities
+    end
+
+    test "does not raise if another function is called" do
+      patch(RefuteAnyCall, :other_function, :patched_result)
+
+      assert RefuteAnyCall.other_function(1) == :patched_result
+
+      refute_any_call RefuteAnyCall.function_with_multiple_arities
+    end
+
+    test "exception formatting" do
+      patch(RefuteAnyCall, :other_function, :patched_result)
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert RefuteAnyCall.function_with_multiple_arities(1) == :patched_result
+      assert RefuteAnyCall.other_function(1) == :patched_result
+
+      expected_message = """
+      \n
+      Unexpected call received, expected no calls:
+
+        Patch.Test.Support.User.RefuteAnyCall.function_with_multiple_arities
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.RefuteAnyCall.function_with_multiple_arities(1)
+        2. Patch.Test.Support.User.RefuteAnyCall.other_function(1)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        refute_any_call RefuteAnyCall.function_with_multiple_arities
+      end
+    end
+  end
+
+
   describe "refute_any_call/2" do
     test "raises if a patched function has a call of any arity (/1)" do
       patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
@@ -73,6 +178,38 @@ defmodule Patch.Test.User.RefuteAnyCallTest do
     test "does not raise if a spied module function has no calls" do
       spy(RefuteAnyCall)
       refute_any_call RefuteAnyCall, :function_with_multiple_arities
+    end
+
+    test "does not raise if another function is called" do
+      patch(RefuteAnyCall, :other_function, :patched_result)
+
+      assert RefuteAnyCall.other_function(1) == :patched_result
+
+      refute_any_call RefuteAnyCall, :function_with_multiple_arities
+    end
+
+    test "exception formatting" do
+      patch(RefuteAnyCall, :other_function, :patched_result)
+      patch(RefuteAnyCall, :function_with_multiple_arities, :patched_result)
+
+      assert RefuteAnyCall.function_with_multiple_arities(1) == :patched_result
+      assert RefuteAnyCall.other_function(1) == :patched_result
+
+      expected_message = """
+      \n
+      Unexpected call received, expected no calls:
+
+        Patch.Test.Support.User.RefuteAnyCall.function_with_multiple_arities
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.RefuteAnyCall.function_with_multiple_arities(1)
+        2. Patch.Test.Support.User.RefuteAnyCall.other_function(1)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        refute_any_call RefuteAnyCall, :function_with_multiple_arities
+      end
     end
   end
 end

--- a/test/user/refute_called_once_test.exs
+++ b/test/user/refute_called_once_test.exs
@@ -1,0 +1,117 @@
+defmodule Patch.Test.User.RefuteCalledOnecTest do
+  use ExUnit.Case
+  use Patch
+
+  alias Patch.Test.Support.User.RefuteCalledOnce
+
+  describe "refute_called_once/1" do
+    test "exact call can be refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      refute_called_once RefuteCalledOnce.example(3, 4)
+    end
+
+    test "exact call that have happened raise UnexpectedCall" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called_once RefuteCalledOnce.example(1, 2)
+      end
+    end
+
+    test "exact call after multiple calls can be refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      refute_called_once RefuteCalledOnce.example(1, 2)
+    end
+
+    test "partial call can be refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      refute_called_once RefuteCalledOnce.example(3, :_)
+      refute_called_once RefuteCalledOnce.example(:_, 4)
+    end
+
+    test "partial call that match raises UnexpectedCall" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called_once RefuteCalledOnce.example(1, :_)
+      end
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called_once RefuteCalledOnce.example(:_, 2)
+      end
+    end
+
+    test "partial call after multiple calls can be refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+      assert RefuteCalledOnce.example(1, 3) == :patched
+      assert RefuteCalledOnce.example(3, 2) == :patched
+
+      refute_called_once RefuteCalledOnce.example(1, :_)
+      refute_called_once RefuteCalledOnce.example(:_, 2)
+    end
+
+    test "an uncalled function can be wildcard refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      refute_called_once RefuteCalledOnce.example(:_, :_)
+    end
+
+    test "any call causes a wildcard to raise UnexpectedCall" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called_once RefuteCalledOnce.example(:_, :_)
+      end
+    end
+
+    test "wildcard call with multiple calls can be refuted" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+      assert RefuteCalledOnce.example(3, 4) == :patched
+
+      refute_called_once RefuteCalledOnce.example(:_, :_)
+    end
+
+    test "exception formatting" do
+      patch(RefuteCalledOnce, :example, :patched)
+
+      assert RefuteCalledOnce.example(1, 2) == :patched
+      assert RefuteCalledOnce.example(3, 4) == :patched
+
+      expected_message = """
+      \n
+      Expected the following call to occur any number of times but once, but it occurred once:
+
+        Patch.Test.Support.User.RefuteCalledOnce.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.RefuteCalledOnce.example(1, 2)
+        2. Patch.Test.Support.User.RefuteCalledOnce.example(3, 4)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        refute_called_once RefuteCalledOnce.example(1, 2)
+      end
+    end
+  end
+end

--- a/test/user/refute_called_test.exs
+++ b/test/user/refute_called_test.exs
@@ -61,5 +61,143 @@ defmodule Patch.Test.User.RefuteCalledTest do
         refute_called RefuteCalled.example(:_, :_)
       end
     end
+
+    test "exception formatting" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+      assert RefuteCalled.example(3, 4) == :patched
+      assert RefuteCalled.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Unexpected call received:
+
+        Patch.Test.Support.User.RefuteCalled.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.RefuteCalled.example(1, 2)
+        2. Patch.Test.Support.User.RefuteCalled.example(3, 4)
+      * 3. Patch.Test.Support.User.RefuteCalled.example(1, 2)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        refute_called RefuteCalled.example(1, 2)
+      end
+    end
+  end
+
+  describe "refute_called/2" do
+    test "exact call can be refuted with literal count" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      refute_called RefuteCalled.example(1, 2), 2
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      refute_called RefuteCalled.example(1, 2), 1
+    end
+
+    test "exact call can be refuted with expression count" do
+      patch(RefuteCalled, :example, :patched)
+
+      unexpected_count = 2
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      refute_called RefuteCalled.example(1, 2), unexpected_count
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      refute_called RefuteCalled.example(1, 2), unexpected_count - 1
+    end
+
+    test "exact calls that have happened count times raise UnexpectedCall" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called RefuteCalled.example(1, 2), 1
+      end
+    end
+
+    test "partial call can be refuted with literal count" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      refute_called RefuteCalled.example(1, :_), 2
+      refute_called RefuteCalled.example(:_, 2), 2
+    end
+
+    test "partial call can be refuted with expression count" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      unexpected_count = 2
+
+      refute_called RefuteCalled.example(1, :_), unexpected_count
+      refute_called RefuteCalled.example(:_, 2), unexpected_count + 1
+    end
+
+    test "partial calls that match raises UnexpectedCall" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called RefuteCalled.example(1, :_), 1
+      end
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called RefuteCalled.example(:_, 2), 1
+      end
+    end
+
+    test "an uncalled function can be wildcard refuted" do
+      patch(RefuteCalled, :example, :patched)
+
+      refute_called RefuteCalled.example(:_, :_), 1
+    end
+
+    test "any call causes a wildcard refute to raise UnexpectedCall" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+
+      assert_raise Patch.UnexpectedCall, fn ->
+        refute_called RefuteCalled.example(:_, :_), 1
+      end
+    end
+
+    test "exception formatting" do
+      patch(RefuteCalled, :example, :patched)
+
+      assert RefuteCalled.example(1, 2) == :patched
+      assert RefuteCalled.example(3, 4) == :patched
+      assert RefuteCalled.example(1, 2) == :patched
+
+      expected_message = """
+      \n
+      Expected any count except 2 of the following calls, but found 2:
+
+        Patch.Test.Support.User.RefuteCalled.example(1, 2)
+
+      Calls which were received (matching calls are marked with *):
+
+      * 1. Patch.Test.Support.User.RefuteCalled.example(1, 2)
+        2. Patch.Test.Support.User.RefuteCalled.example(3, 4)
+      * 3. Patch.Test.Support.User.RefuteCalled.example(1, 2)
+      """
+
+      assert_raise Patch.UnexpectedCall, expected_message, fn ->
+        refute_called RefuteCalled.example(1, 2), 2
+      end
+    end
   end
 end


### PR DESCRIPTION
- `assert_called/1` now has a companion, `assert_called/2`, which
  accepts a number of calls to assert as well.
- `refute_called/1` now has a companion, `refute_called/2`, which
  accepts a number of calls to refute as well.
- `assert_called_once/1` acts like `assert_called/2` with a number
  of calls set to 1.  The message is slightly nicer to reflect the
  author's intent
- `refute_called_once/1` acts like `refute_called/2` with a number
  of calls set to 1.  The message is slightly nicer to reflect the
  author's intent
- `assert_any_call/2` now has a macro form in `assert_any_call/1` for
  more ergnomic assertions
- `refute_any_call/2` now has a macro form in `refute_any_call/1` for
  more ergonomic assertions