### PR TITLE
Feature/matching assertions

### DIFF
--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -101,7 +101,8 @@ defmodule Patch do
   @doc """
   Given a call will assert that a matching call was observed by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/3` and `assert_received/2`.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -109,9 +110,9 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   assert_called Example.function(1, 2, 3)   # passes
-  assert_called Example.function(1, :_, 3)  # passes
+  assert_called Example.function(1, _, 3)   # passes
   assert_called Example.function(4, 5, 6)   # fails
-  assert_called Example.function(4, :_, 6)  # fails
+  assert_called Example.function(4, _, 6)   # fails
   ```
   """
   @spec assert_called(Macro.t()) :: Macro.t()
@@ -125,7 +126,9 @@ defmodule Patch do
   Given a call will assert that a matching call was observed exactly the number of times provided
   by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/3` and `assert_received/2`.  Any binds will bind to the latest matching call
+  values.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -133,12 +136,12 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   assert_called Example.function(1, 2, 3), 1   # passes
-  assert_called Example.function(1, :_, 3), 1  # passes
+  assert_called Example.function(1, _, 3), 1   # passes
 
   Example.function(1, 2, 3)
 
   assert_called Example.function(1, 2, 3), 2   # passes
-  assert_called Example.function(1, :_, 3), 2  # passes
+  assert_called Example.function(1, _, 3), 2   # passes
   ```
   """
   @spec assert_called(call :: Macro.t(), count :: Macro.t()) :: Macro.t()
@@ -151,7 +154,8 @@ defmodule Patch do
   @doc """
   Given a call will assert that a matching call was observed exactly once by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/3` and `assert_received/2`.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -159,12 +163,12 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   assert_called_once Example.function(1, 2, 3)   # passes
-  assert_called_once Example.function(1, :_, 3)  # passes
+  assert_called_once Example.function(1, _, 3)   # passes
 
   Example.function(1, 2, 3)
 
   assert_called_once Example.function(1, 2, 3)   # fails
-  assert_called_once Example.function(1, :_, 3)  # fails
+  assert_called_once Example.function(1, _, 3)   # fails
   ```
   """
   @spec assert_called_once(call :: Macro.t()) :: Macro.t()
@@ -564,7 +568,7 @@ defmodule Patch do
   @doc """
   Given a call will refute that a matching call was observed by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -572,9 +576,9 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   refute_called Example.function(4, 5, 6)   # passes
-  refute_called Example.function(4, :_, 6)  # passes
+  refute_called Example.function(4, _, 6)   # passes
   refute_called Example.function(1, 2, 3)   # fails
-  refute_called Example.function(1, :_, 3)  # fails
+  refute_called Example.function(1, _, 3)   # fails
   ```
   """
   @spec refute_called(call :: Macro.t()) :: Macro.t()
@@ -588,7 +592,7 @@ defmodule Patch do
   Given a call will refute that a matching call was observed exactly the number of times provided
   by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -596,12 +600,12 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   refute_called Example.function(1, 2, 3), 2   # passes
-  refute_called Example.function(1, :_, 3), 2  # passes
+  refute_called Example.function(1, _, 3), 2   # passes
 
   Example.function(1, 2, 3)
 
   refute_called Example.function(1, 2, 3), 1   # passes
-  refute_called Example.function(1, :_, 3), 1  # passes
+  refute_called Example.function(1, _, 3), 1   # passes
   ```
   """
   @spec refute_called(call :: Macro.t(), count :: Macro.t()) :: Macro.t()
@@ -614,7 +618,7 @@ defmodule Patch do
   @doc """
   Given a call will refute that a matching call was observed exactly once by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -622,12 +626,12 @@ defmodule Patch do
   Example.function(1, 2, 3)
 
   refute_called_once Example.function(1, 2, 3)   # fails
-  refute_called_once Example.function(1, :_, 3)  # fails
+  refute_called_once Example.function(1, _, 3)   # fails
 
   Example.function(1, 2, 3)
 
   refute_called_once Example.function(1, 2, 3)   # passes
-  refute_called_once Example.function(1, :_, 3)  # passes
+  refute_called_once Example.function(1, _, 3)   # passes
   ```
   """
   @spec refute_called_once(call :: Macro.t()) :: Macro.t()

--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -169,10 +169,8 @@ defmodule Patch do
   """
   @spec assert_called_once(call :: Macro.t()) :: Macro.t()
   defmacro assert_called_once(call) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
     quote do
-      Patch.Assertions.assert_called_once(unquote(module), unquote(function), unquote(arguments))
+      Patch.Assertions.assert_called_once(unquote(call))
     end
   end
 
@@ -581,10 +579,8 @@ defmodule Patch do
   """
   @spec refute_called(call :: Macro.t()) :: Macro.t()
   defmacro refute_called(call) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
     quote do
-      Patch.Assertions.refute_called(unquote(module), unquote(function), unquote(arguments))
+      Patch.Assertions.refute_called(unquote(call))
     end
   end
 
@@ -610,10 +606,8 @@ defmodule Patch do
   """
   @spec refute_called(call :: Macro.t(), count :: Macro.t()) :: Macro.t()
   defmacro refute_called(call, count) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
     quote do
-      Patch.Assertions.refute_called(unquote(module), unquote(function), unquote(arguments), unquote(count))
+      Patch.Assertions.refute_called(unquote(call), unquote(count))
     end
   end
 
@@ -638,10 +632,8 @@ defmodule Patch do
   """
   @spec refute_called_once(call :: Macro.t()) :: Macro.t()
   defmacro refute_called_once(call) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
     quote do
-      Patch.Assertions.refute_called_once(unquote(module), unquote(function), unquote(arguments))
+      Patch.Assertions.refute_called_once(unquote(call))
     end
   end
 

--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -41,6 +41,11 @@ defmodule Patch do
       import unquote(__MODULE__)
       import Patch.Mock.Value, except: [advance: 1, next: 2]
 
+      require Patch.Macro
+      require Patch.Mock
+      require Patch.Assertions
+
+
       setup do
         start_supervised!(Patch.Supervisor)
         :ok
@@ -111,8 +116,8 @@ defmodule Patch do
   """
   @spec assert_called(Macro.t()) :: Macro.t()
   defmacro assert_called(call) do
-    quote bind_quoted: [call: call] do
-      Patch.Assertions.assert_called(call)
+    quote do
+      Patch.Assertions.assert_called(unquote(call))
     end
   end
 
@@ -138,10 +143,8 @@ defmodule Patch do
   """
   @spec assert_called(call :: Macro.t(), count :: Macro.t()) :: Macro.t()
   defmacro assert_called(call, count) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
     quote do
-      Patch.Assertions.assert_called(unquote(module), unquote(function), unquote(arguments), unquote(count))
+      Patch.Assertions.assert_called(unquote(call), unquote(count))
     end
   end
 

--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -111,10 +111,8 @@ defmodule Patch do
   """
   @spec assert_called(Macro.t()) :: Macro.t()
   defmacro assert_called(call) do
-    {module, function, arguments} = Macro.decompose_call(call)
-
-    quote do
-      Patch.Assertions.assert_called(unquote(module), unquote(function), unquote(arguments))
+    quote bind_quoted: [call: call] do
+      Patch.Assertions.assert_called(call)
     end
   end
 

--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -41,7 +41,7 @@ defmodule Patch.Assertions do
   Given a call will assert that a matching call was observed by the patched function.
 
   This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
-  `assert_receive/1` and `assert_received/1`.
+  `assert_receive/3` and `assert_received/2`.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -89,7 +89,7 @@ defmodule Patch.Assertions do
   by the patched function.
 
   This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
-  `assert_receive/1` and `assert_received/1`.  The value bound will be the from the latest call.
+  `assert_receive/3` and `assert_received/2`.  The value bound will be the from the latest call.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -147,7 +147,7 @@ defmodule Patch.Assertions do
   Given a call will assert that a matching call was observed exactly once by the patched function.
 
   This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
-  `assert_receive/1` and `assert_received/1`.
+  `assert_receive/3` and `assert_received/2`.
 
   ```elixir
   patch(Example, :function, :patch)

--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -354,6 +354,7 @@ defmodule Patch.Assertions do
 
   def format_history(module, calls) do
     calls
+    |> Enum.reverse()
     |> Enum.with_index(1)
     |> Enum.map(fn {{matches, {function, arguments}}, i} ->
       marker =

--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -16,8 +16,8 @@ defmodule Patch.Assertions do
   Patch.Asertions.assert_any_call(Example, :function)   # passes
   ```
 
-  There is a convenience delegate in the Developer Interface, `Patch.assert_any_call/2` which
-  should be preferred over calling this function directly.
+  There are convenience delegates in the Developer Interface, `Patch.assert_any_call/1` and
+  `Patch.assert_any_call/2` which should be preferred over calling this function directly.
   """
   @spec assert_any_call(module :: module(), function :: atom()) :: nil
   def assert_any_call(module, function) do
@@ -40,7 +40,8 @@ defmodule Patch.Assertions do
   @doc """
   Given a call will assert that a matching call was observed by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/1` and `assert_received/1`.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -48,12 +49,13 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.assert_called(Example, :function, [1, 2, 3])   # passes
-  Patch.Assertions.assert_called(Example, :function, [1, :_, 3])  # passes
+  Patch.Assertions.assert_called(Example, :function, [1, _, 3])  # passes
   Patch.Assertions.assert_called(Example, :function, [4, 5, 6])   # fails
-  Patch.Assertions.assert_called(Example, :function, [4, :_, 6])  # fails
+  Patch.Assertions.assert_called(Example, :function, [4, _, 6])  # fails
   ```
+
   There is a convenience macro in the Developer Interface, `Patch.assert_called/1` which should be
-  preferred over calling this function directly.
+  preferred over calling this macro directly.
   """
   @spec assert_called(call :: Macro.t()) :: Macro.t()
   defmacro assert_called(call) do
@@ -86,7 +88,8 @@ defmodule Patch.Assertions do
   Given a call will assert that a matching call was observed exactly the number of times provided
   by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/1` and `assert_received/1`.  The value bound will be the from the latest call.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -94,16 +97,16 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.assert_called(Example, :function, [1, 2, 3], 1)   # passes
-  Patch.Assertions.assert_called(Example, :function, [1, :_, 3], 1)  # passes
+  Patch.Assertions.assert_called(Example, :function, [1, _, 3], 1)  # passes
 
   Example.function(1, 2, 3)
 
   Patch.Assertions.assert_called(Example, :function, [1, 2, 3], 2)   # passes
-  Patch.Assertions.assert_called(Example, :function, [1, :_, 3], 2)  # passes
+  Patch.Assertions.assert_called(Example, :function, [1, _, 3], 2)  # passes
   ```
 
   There is a convenience macro in the Developer Interface, `Patch.assert_called/2` which
-  should be preferred over calling this function directly.
+  should be preferred over calling this macro directly.
   """
   @spec assert_called(call :: Macro.t(), count :: non_neg_integer()) :: Macro.t()
   defmacro assert_called(call, count) do
@@ -143,7 +146,8 @@ defmodule Patch.Assertions do
   @doc """
   Given a call will assert that a matching call was observed exactly once by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns and will perform non-hygienic binding similar to ExUnit's
+  `assert_receive/1` and `assert_received/1`.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -151,16 +155,16 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.assert_called_once(Example, :function, [1, 2, 3])   # passes
-  Patch.Assertions.assert_called_once(Example, :function, [1, :_, 3])  # passes
+  Patch.Assertions.assert_called_once(Example, :function, [1, _, 3])  # passes
 
   Example.function(1, 2, 3)
 
   Patch.Assertions.assert_called_once(Example, :function, [1, 2, 3])   # fails
-  Patch.Assertions.assert_called_once(Example, :function, [1, :_, 3])  # fails
+  Patch.Assertions.assert_called_once(Example, :function, [1, _, 3])  # fails
   ```
 
   There is a convenience macro in the Developer Interface, `Patch.assert_called_once/1` which
-  should be preferred over calling this function directly.
+  should be preferred over calling this macro directly.
   """
   @spec assert_called_once(call :: Macro.t()) :: Macro.t()
   defmacro assert_called_once(call) do
@@ -211,8 +215,8 @@ defmodule Patch.Assertions do
   Patch.Assertions.refute_any_call(Example, :function)   # fails
   ```
 
-  There is a convenience delegate in the Developer Interface, `Patch.refute_any_call/2` which
-  should be preferred over calling this function directly.
+  There are convenience delegates in the Developer Interface, `Patch.refute_any_call/1` and
+  `Patch.refute_any_call/2` which should be preferred over calling this function directly.
   """
   @spec refute_any_call(module :: module(), function :: atom()) :: nil
   def refute_any_call(module, function) do
@@ -235,7 +239,7 @@ defmodule Patch.Assertions do
   @doc """
   Given a call will refute that a matching call was observed by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -243,13 +247,13 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.refute_called(Example, :function, [4, 5, 6])   # passes
-  Patch.Assertions.refute_called(Example, :function, [4, :_, 6])  # passes
+  Patch.Assertions.refute_called(Example, :function, [4, _, 6])  # passes
   Patch.Assertions.refute_called(Example, :function, [1, 2, 3])   # fails
-  Patch.Assertions.refute_called(Example, :function, [1, :_, 3])  # passes
+  Patch.Assertions.refute_called(Example, :function, [1, _, 3])  # passes
   ```
 
   There is a convenience macro in the Developer Interface, `Patch.refute_called/1` which should be
-  preferred over calling this function directly.
+  preferred over calling this macro directly.
   """
   @spec refute_called(call :: Macro.t()) :: Macro.t()
   defmacro refute_called(call) do
@@ -279,7 +283,7 @@ defmodule Patch.Assertions do
   Given a call will refute that a matching call was observed exactly the number of times provided
   by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -287,16 +291,16 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.refute_called(Example, :function, [1, 2, 3], 2)   # passes
-  Patch.Assertions.refute_called(Example, :function, [1, :_, 3], 2)  # passes
+  Patch.Assertions.refute_called(Example, :function, [1, _, 3], 2)  # passes
 
   Example.function(1, 2, 3)
 
   Patch.Assertions.refute_called(Example, :function, [1, 2, 3], 1)   # passes
-  Patch.Assertions.refute_called(Example, :function, [1, :_, 3], 1)  # passes
+  Patch.Assertions.refute_called(Example, :function, [1, _, 3], 1)  # passes
   ```
 
   There is a convenience macro in the Developer Interface, `Patch.refute_called/2` which
-  should be preferred over calling this function directly.
+  should be preferred over calling this macro directly.
   """
   @spec refute_called(call :: Macro.t(), count :: non_neg_integer()) :: Macro.t()
   defmacro refute_called(call, count) do
@@ -327,7 +331,7 @@ defmodule Patch.Assertions do
   @doc """
   Given a call will refute that a matching call was observed exactly once by the patched function.
 
-  The call can use the special sentinal `:_` as a wildcard match.
+  This macro fully supports patterns.
 
   ```elixir
   patch(Example, :function, :patch)
@@ -335,16 +339,16 @@ defmodule Patch.Assertions do
   Example.function(1, 2, 3)
 
   Patch.Assertions.refute_called_once(Example, :function, [1, 2, 3])   # fails
-  Patch.Assertions.refute_called_once(Example, :function, [1, :_, 3])  # fails
+  Patch.Assertions.refute_called_once(Example, :function, [1, _, 3])  # fails
 
   Example.function(1, 2, 3)
 
   Patch.Assertions.refute_called_once(Example, :function, [1, 2, 3])   # passes
-  Patch.Assertions.refute_called_once(Example, :function, [1, :_, 3])  # passes
+  Patch.Assertions.refute_called_once(Example, :function, [1, _, 3])  # passes
   ```
 
   There is a convenience macro in the Developer Interface, `Patch.refute_called_once/1` which
-  should be preferred over calling this function directly.
+  should be preferred over calling this macro directly.
   """
   @spec refute_called_once(call :: Macro.t()) :: Macro.t()
   defmacro refute_called_once(call) do
@@ -373,7 +377,7 @@ defmodule Patch.Assertions do
   end
 
   @doc """
-  Prints a list of patterns AST as an argument list.
+  Formats the AST for a list of patterns AST as they would appear in an argument list.
   """
   @spec format_patterns(patterns :: [term()]) :: String.t()
   defmacro format_patterns(patterns) do
@@ -382,7 +386,10 @@ defmodule Patch.Assertions do
     |> String.slice(1..-2)
   end
 
-  @spec format_history(module :: Module.t(), calls :: [{atom(), [term()]}]) :: String.t()
+  @doc """
+  Formats history entries like those returned by `Patch.Mock.match_history/1`.
+  """
+  @spec format_history(module :: Module.t(), calls :: [{boolean(), {atom(), [term()]}}]) :: String.t()
   def format_history(module, calls) do
     calls
     |> Enum.reverse()

--- a/lib/patch/macro.ex
+++ b/lib/patch/macro.ex
@@ -1,0 +1,103 @@
+defmodule Patch.Macro do
+  @doc """
+  Utility function that acts like `inspect/1` but prints out the Macro as code.
+  """
+  @spec debug(ast :: Macro.t()) :: Macro.t()
+  def debug(ast) do
+    ast
+    |> Macro.to_string()
+    |> IO.puts()
+
+    ast
+  end
+
+  @doc """
+  Performs an non-hygienic match.
+
+  If the match succeeds true is returned, otherwise a MatchError is raised.
+
+  Since the match is non-hygienic pins can be used from the user-scope and binds will effect
+  user-scope.
+  """
+  @spec match(pattern :: Macro.t(), expression :: Macro.t()) :: Macro.t()
+  defmacro match(pattern, expression) do
+    user_pattern = user_variables(pattern)
+    pattern_expression = pattern_expression(pattern)
+    variables = variables(pattern)
+
+    quote generated: true do
+      unquote(pattern_expression) =
+        case unquote(expression) do
+          unquote(user_pattern) ->
+            _ = unquote(variables)
+            unquote(expression)
+
+          _ ->
+            raise MatchError, term: unquote(expression)
+        end
+
+      _ = unquote(variables)
+      true
+    end
+  end
+
+  @doc """
+  Performs a match, return true if match matches, false otherwise.
+  """
+  @spec match?(pattern :: Macro.t(), expression :: Macro.t()) :: Macro.t()
+  defmacro match?(pattern, expression) do
+    quote generated: true do
+      try do
+        Patch.Macro.match(unquote(pattern), unquote(expression))
+        true
+      rescue
+        MatchError ->
+          false
+      end
+    end
+  end
+
+  ## Private
+
+  defp pattern_expression(pattern) do
+    Macro.prewalk(pattern, fn
+      {:^, _, [{name, meta, _}]}  ->
+        {name, meta, nil}
+
+      {:_, _, _} ->
+        unique_variable()
+
+      node ->
+        node
+    end)
+  end
+
+  defp unique_variable do
+    {:"_ignore#{:erlang.unique_integer([:positive])}", [generated: true], nil}
+  end
+
+  defp user_variables(pattern) do
+    Macro.prewalk(pattern, fn
+      {name, meta, context} when is_atom(name) and is_atom(context) ->
+        {name, meta, nil}
+
+      node ->
+        node
+    end)
+  end
+
+  defp variables(pattern) do
+    pattern
+    |> Macro.prewalk([], fn
+      {:_, _, _}, acc ->
+        {node, acc}
+
+      {name, meta, context} = node, acc when is_atom(name) and is_atom(context) ->
+        {node, [{name, meta, nil} | acc]}
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+end

--- a/lib/patch/macro.ex
+++ b/lib/patch/macro.ex
@@ -89,11 +89,20 @@ defmodule Patch.Macro do
   defp variables(pattern) do
     pattern
     |> Macro.prewalk([], fn
-      {:_, _, _}, acc ->
+      {:_, _, _} = node, acc ->
         {node, acc}
 
       {name, meta, context} = node, acc when is_atom(name) and is_atom(context) ->
-        {node, [{name, meta, nil} | acc]}
+        ignored? =
+          name
+          |> Atom.to_string()
+          |> String.starts_with?("_")
+
+        if ignored? do
+          {node, acc}
+        else
+          {node, [{name, meta, nil} | acc]}
+        end
 
       node, acc ->
         {node, acc}

--- a/lib/patch/mock.ex
+++ b/lib/patch/mock.ex
@@ -109,6 +109,12 @@ defmodule Patch.Mock do
     Mock.Server.history(module)
   end
 
+  @doc """
+  Given a call finds the latest call that matched.
+
+  Returns `{:ok, {function, arguments}}` if a matching call is found, `false` otherwise.
+  """
+  @spec latest_match(call :: Macro.t()) :: Macro.t()
   defmacro latest_match(call) do
     {module, function, pattern} = Macro.decompose_call(call)
 

--- a/lib/patch/mock.ex
+++ b/lib/patch/mock.ex
@@ -109,6 +109,27 @@ defmodule Patch.Mock do
     Mock.Server.history(module)
   end
 
+  defmacro latest_match(call) do
+    {module, function, pattern} = Macro.decompose_call(call)
+
+    quote do
+      unquote(module)
+      |> Patch.Mock.history()
+      |> Patch.Mock.History.entries(:desc)
+      |> Enum.find_value(fn
+        {unquote(function), arguments} = call ->
+          if Patch.Macro.match?(unquote(pattern), arguments) do
+            {:ok, call}
+          else
+            false
+          end
+
+        _ ->
+          false
+      end)
+    end
+  end
+
   @doc """
   Decorates the history with whether or not the call in the history matches the provided call.
 

--- a/lib/patch/mock.ex
+++ b/lib/patch/mock.ex
@@ -5,7 +5,6 @@ defmodule Patch.Mock do
   @typedoc """
   What exposures should be made in a module.
 
-
   - `:public` will only expose the public functions
   - `:all` will expose both public and private functions
   - A list of exports can be provided, they will be added to the `:public` functions.
@@ -31,46 +30,47 @@ defmodule Patch.Mock do
   """
   @type option :: exposes_option() | history_limit_option()
 
-
   @doc """
-  Given a list of expected arguments and actual arguments checks to see if the
-  two lists are compatible.
+  Returns the number of times a matching call has been observed
 
-  In the `expected_arguments` the wildcard atom, `:_` can be used to match any
-  value.
-  """
-  @spec arguments_compatible?(expected_arguments :: [term()], actual_arguments :: [term()]) :: boolean()
-  def arguments_compatible?(expected_arguments, actual_arguments) do
-    do_arguments_compatible?(
-      expected_arguments,
-      Enum.count(expected_arguments),
-      actual_arguments,
-      Enum.count(actual_arguments)
-    )
-  end
-
-  @doc """
-  Returns the number of times the given name has been called in the given module with the given
-  arguments.
-
-  The arguments list can include the wildcard atom, `:_`, to match any argument in that position.
+  The call arguments support any valid patterns.
 
   This function uses the Mock's history to check, if the history is limited or disabled then calls
   that have happened may report back as never having happened.
   """
-  @spec call_count(module :: module(), name :: atom(), expected_arguments :: [term()]) :: non_neg_integer()
-  def call_count(module, name, expected_arguments) do
-    module
-    |> history()
-    |> Mock.History.entries(:desc)
-    |> Enum.filter(fn
-      {^name, actual_arguments} ->
-        arguments_compatible?(expected_arguments, actual_arguments)
+  @spec call_count(call :: Macro.t()) :: Macro.t()
+  defmacro call_count(call) do
+    quote do
+      unquote(call)
+      |> Patch.Mock.matches()
+      |> Enum.count()
+    end
+  end
 
-      _ ->
-        false
-    end)
-    |> Enum.count()
+  @doc """
+  Checks to see if the call has been observed.
+
+  The call arguments support any valid patterns.
+
+  This function uses the Mock's history to check, if the history is limited or disabled then calls
+  that have happened may report back as never having happened.
+  """
+  @spec called?(call :: Macro.t()) :: Macro.t()
+  defmacro called?(call) do
+    {module, function, pattern} = Macro.decompose_call(call)
+
+    quote do
+      unquote(module)
+      |> Patch.Mock.history()
+      |> Patch.Mock.History.entries(:desc)
+      |> Enum.any?(fn
+        {unquote(function), arguments} ->
+          Patch.Macro.match?(unquote(pattern), arguments)
+
+        _ ->
+          false
+      end)
+    end
   end
 
   @doc """
@@ -85,29 +85,6 @@ defmodule Patch.Mock do
     |> history()
     |> Mock.History.entries(:desc)
     |> Enum.any?(&match?({^name, _}, &1))
-  end
-
-  @doc """
-  Checks to see if a fucntion with the given name has been called in the given module with the
-  given arguments.
-
-  The arguments list can include the wildcard atom, `:_`, to match any argument in that position.
-
-  This function uses the Mock's history to check, if the history is limited or disabled then calls
-  that have happened may report back as never having happened.
-  """
-  @spec called?(module :: module(), name :: atom(), expected_arguments :: [term()]) :: boolean()
-  def called?(module, name, expected_arguments) do
-    module
-    |> history()
-    |> Mock.History.entries(:desc)
-    |> Enum.any?(fn
-      {^name, actual_arguments} ->
-        arguments_compatible?(expected_arguments, actual_arguments)
-
-      _ ->
-        false
-    end)
   end
 
   @doc """
@@ -130,6 +107,60 @@ defmodule Patch.Mock do
   @spec history(module :: module()) :: Mock.History.t()
   def history(module) do
     Mock.Server.history(module)
+  end
+
+  @doc """
+  Decorates the history with whether or not the call in the history matches the provided call.
+
+  Provided call arguments support any valid patterns.
+
+  Returns the calls descending (newest first) as a two-tuple in the form
+
+  `{boolean(), {atom(), [term()]}}`
+
+  The first element indicates whether the call matches the provided call.
+
+  The second element is a tuple of function name and arguments.
+
+  This macro uses the Mock's history to check, if the history is limited or disabled then calls
+  that have happened may report back as never having happened.
+  """
+  @spec match_history(call :: Macro.t()) :: Macro.t()
+  defmacro match_history(call) do
+    {module, function, pattern} = Macro.decompose_call(call)
+
+    quote do
+      unquote(module)
+      |> Patch.Mock.history()
+      |> Patch.Mock.History.entries(:desc)
+      |> Enum.map(fn
+        {unquote(function), arguments} = call ->
+          {Patch.Macro.match?(unquote(pattern), arguments), call}
+
+        call ->
+          {false, call}
+      end)
+    end
+  end
+
+  @doc """
+  Returns all the calls in the history that match the provided call.
+
+  Provided call arguments support any valid patterns.
+
+  Returns the calls descending (newest first) as the list of arguments in the call
+
+  This macro uses the Mock's history to check, if the history is limited or disabled then calls
+  that have happened may report back as never having happened.
+  """
+  @spec matches(call :: Macro.t()) :: Macro.t()
+  defmacro matches(call) do
+    quote do
+      unquote(call)
+      |> Patch.Mock.match_history()
+      |> Enum.filter(&elem(&1, 0))
+      |> Enum.map(fn {true, {_function, arguments}} -> arguments end)
+    end
   end
 
   @doc """
@@ -173,29 +204,5 @@ defmodule Patch.Mock do
   @spec restore(module :: module()) :: :ok
   def restore(module) do
     Mock.Server.restore(module)
-  end
-
-  ## Private
-
-  defp do_argument_compatible?({:_, _}) do
-    true
-  end
-
-  defp do_argument_compatible?({same, same}) do
-    true
-  end
-
-  defp do_argument_compatible?(_) do
-    false
-  end
-
-  defp do_arguments_compatible?(expected_arguments, same, actual_arguments, same) do
-    expected_arguments
-    |> Enum.zip(actual_arguments)
-    |> Enum.all?(&do_argument_compatible?/1)
-  end
-
-  defp do_arguments_compatible?(_, _, _, _) do
-    false
   end
 end

--- a/lib/patch/mock/server.ex
+++ b/lib/patch/mock/server.ex
@@ -96,7 +96,7 @@ defmodule Patch.Mock.Server do
   """
   @spec history(module :: module()) :: History.t()
   def history(module) do
-    call(module, :history, fn -> History.new() end)
+    call(module, :history, &History.new/0)
   end
 
   @doc """

--- a/pages/guide-book/02-patching.md
+++ b/pages/guide-book/02-patching.md
@@ -147,15 +147,23 @@ defmodule PatchExample do
 end
 ```
 
-`assert_called/1` supports the `:_` wildcard atom.  In the above example the following assertion would also pass.
+`assert_called/1` supports full pattern matching and non-hygienic binds.  This is similar to how
+ExUnit's `assert_receive/3` and `assert_received/2` work.
 
 ```elixir
-assert_called String.upcase(:_)
+# Wildcards are supported
+assert_called String.upcase(_)
+
+# Pinned variables are supported
+expected = "hello"
+assert_called String.upcase(^expected)
+
+# Unpinned variables are supported
+assert_called String.upcase(argument)
+assert argument == "hello"
 ```
 
-This can be useful when some of the arguments are complex or uninteresting for the unit test.
-
-Tests can also refute that a call has occurred with the `refute_called/1` macro.  This macro works in much the same way as `assert_called/1` and also supports the `:_` wildcard atom.
+Tests can also refute that a call has occurred with the `refute_called/1` macro.  This macro works in much the same way as `assert_called/1` and has full pattern support.
 
 ```elixir
 defmodule PatchExample do
@@ -197,13 +205,22 @@ defmodule PatchExample do
 end
 ```
 
-`assert_called_once/1` supports the `:_` wildcard atom.  In the above example the following assertion would behave identically.
+`assert_called_once/1` supports patterns and binds just like `assert_called/1`.  In the above example the following assertion would behave identically.
 
 ```elixir
-assert_called_once String.upcase(:_)
+# Wildcards are supported
+assert_called_once String.upcase(_)
+
+# Pinned variables are supported
+expected = "hello"
+assert_called_once String.upcase(^expected)
+
+# Unpinned variables are supported
+assert_called_once String.upcase(argument)
+assert argument == "hello"
 ```
 
-Tests can also refute that a call has occurred once with the `refute_called_once/1` macro.  This macro works in much the same way as `assert_called_once/1` and also supports the `:_` wildcard atom.
+Tests can also refute that a call has occurred once with the `refute_called_once/1` macro.  This macro works in much the same way as `assert_called_once/1` and has full pattern support.
 
 ```elixir
 defmodule PatchExample do
@@ -253,13 +270,24 @@ defmodule PatchExample do
 end
 ```
 
-`assert_called/2` supports the `:_` wildcard atom.  In the above example the following assertion would behave identically.
+`assert_called/2` supports patterns and binds just like `assert_called/1`.  Since multiple calls might match any binds bind to the latest matching call.
+
+In the above example the following assertion would behave identically.
 
 ```elixir
-assert_called String.upcase(:_), 3
+# Wildcards are supported
+assert_called String.upcase(_), 3
+
+# Pinned variables are supported
+expected = "hello"
+assert_called String.upcase(^expected), 3
+
+# Unpinned variables are supported
+assert_called String.upcase(argument), 3
+assert argument == "hello"
 ```
 
-Tests can also refute that a call has happened some given number of times exactly with the `refute_called/2` macro.  This macro works in much the same way as `assert_called/2` and also supports the `:_` wildcard atom.
+Tests can also refute that a call has happened some an exact number of times with the `refute_called/2` macro.  This macro works in much the same way as `assert_called/2` and also has full pattern support.
 
 ```elixir
 defmodule PatchExample do
@@ -283,7 +311,6 @@ defmodule PatchExample do
   end
 end
 ```
-
 
 ### Asserting / Refuting Multiple Arities
 

--- a/test/support/unit/mock.ex
+++ b/test/support/unit/mock.ex
@@ -1,0 +1,5 @@
+defmodule Patch.Test.Support.Unit.Mock do
+  def example(a) do
+    {:original, a}
+  end
+end

--- a/test/unit/patch/macro_test.exs
+++ b/test/unit/patch/macro_test.exs
@@ -37,6 +37,16 @@ defmodule Patch.Test.Unit.Patch.MacroTest do
       assert x == :unbound
     end
 
+    test "can match unused variables" do
+      assert Patch.Macro.match?(_x, 1)
+    end
+
+    test "can match a mix of used and unused variabled, but does not bind them" do
+      x = :unbound
+      assert Patch.Macro.match?({x, _y}, {1, 2})
+      assert x == :unbound
+    end
+
     test "functionality works in arbitrarily complex expressions" do
       x = 1
       assert Patch.Macro.match?([^x, y, _, %{a: 1}], [1, 2, 3, %{a: 1, b: 2}])
@@ -77,6 +87,15 @@ defmodule Patch.Test.Unit.Patch.MacroTest do
 
     test "can match variables and binds them" do
       assert Patch.Macro.match(x, 1)
+      assert x == 1
+    end
+
+    test "can match unused variables" do
+      assert Patch.Macro.match(_x, 1)
+    end
+
+    test "can match a mix of used and unused variabled" do
+      assert Patch.Macro.match({x, _y}, {1, 2})
       assert x == 1
     end
 

--- a/test/unit/patch/macro_test.exs
+++ b/test/unit/patch/macro_test.exs
@@ -1,0 +1,89 @@
+defmodule Patch.Test.Unit.Patch.MacroTest do
+  use ExUnit.Case
+  use Patch
+
+  require Patch.Macro
+
+  describe "match?/2" do
+    test "can match literal expressions" do
+      assert Patch.Macro.match?(1, 1)
+    end
+
+    test "can mismatch literal expressions" do
+      refute Patch.Macro.match?(1, 2)
+    end
+
+    test "can match wildcards" do
+      assert Patch.Macro.match?(_, 1)
+    end
+
+    test "can match multiple wildcards" do
+      assert Patch.Macro.match?({_, _}, {1, 2})
+    end
+
+    test "can match pins" do
+     x = 1
+     assert Patch.Macro.match?(^x, 1)
+    end
+
+    test "can mismatch pins" do
+      x = 1
+      refute Patch.Macro.match?(^x, 2)
+    end
+
+    test "can match variables, but does not bind them" do
+      x = :unbound
+      assert Patch.Macro.match?(x, 1)
+      assert x == :unbound
+    end
+
+    test "functionality works in arbitrarily complex expressions" do
+      x = 1
+      assert Patch.Macro.match?([^x, y, _, %{a: 1}], [1, 2, 3, %{a: 1, b: 2}])
+    end
+  end
+
+  describe "match/2" do
+    test "can match literal expressions" do
+      assert Patch.Macro.match(1, 1)
+    end
+
+    test "raise MatchError on literal expressions mismatch" do
+      assert_raise MatchError, "no match of right hand side value: 2", fn ->
+        Patch.Macro.match(1, 2)
+      end
+    end
+
+    test "can match wildcards" do
+      assert Patch.Macro.match(_, 1)
+    end
+
+    test "can match multiple wildcards" do
+      assert Patch.Macro.match({_, _}, {1, 2})
+    end
+
+    test "can match pins" do
+     x = 1
+     assert Patch.Macro.match(^x, 1)
+    end
+
+    test "raise MatchError on mismatch pins" do
+      x = 1
+
+      assert_raise MatchError, "no match of right hand side value: 2", fn ->
+        Patch.Macro.match(^x, 2)
+      end
+    end
+
+    test "can match variables and binds them" do
+      assert Patch.Macro.match(x, 1)
+      assert x == 1
+    end
+
+    test "functionality works in arbitrarily complex expressions" do
+      x = 1
+      assert Patch.Macro.match([^x, y, _, %{a: 1}], [1, 2, 3, %{a: 1, b: 2}])
+      assert y == 2
+    end
+  end
+end

--- a/test/unit/patch/mock_test.exs
+++ b/test/unit/patch/mock_test.exs
@@ -1,0 +1,860 @@
+defmodule Patch.Test.Unit.Patch.MockTest do
+  use ExUnit.Case
+  use Patch
+
+  alias Patch.Mock
+  alias Patch.Test.Support.Unit.Mock, as: MockTarget
+
+  require Patch.Mock
+  require Patch.Macro
+
+  describe "called?/1 with no calls" do
+    test "no match" do
+      spy(MockTarget)
+
+      refute Mock.called?(MockTarget.example(:test))
+    end
+  end
+
+  describe "called?/1 with a single call" do
+    test "exact match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.called?(MockTarget.example(:test))
+    end
+
+    test "exact mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      refute Mock.called?(MockTarget.example(:other))
+    end
+
+    test "variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.called?(MockTarget.example(variable))
+    end
+
+    test "variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      variable = :test
+
+      MockTarget.example(variable)
+
+      assert Mock.called?(MockTarget.example(^variable))
+    end
+
+    test "other variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      argument = :test
+      MockTarget.example(argument)
+
+      variable = :test
+      assert Mock.called?(MockTarget.example(^variable))
+    end
+
+    test "literal argument, pinned variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      variable = :test
+      assert Mock.called?(MockTarget.example(^variable))
+    end
+
+    test "wildcard match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.called?(MockTarget.example(_))
+    end
+
+    test "empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+
+      assert Mock.called?(MockTarget.example([]))
+    end
+
+    test "empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([:a, :b, :c])
+
+      refute Mock.called?(MockTarget.example([]))
+    end
+
+    test "non-empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.called?(MockTarget.example([_ | _]))
+    end
+
+    test "non-empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+
+      refute Mock.called?(MockTarget.example([_ | _]))
+    end
+
+    test "empty map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.called?(MockTarget.example(%{}))
+    end
+
+    test "partial map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.called?(MockTarget.example(%{a: 1}))
+      assert Mock.called?(MockTarget.example(%{b: 2}))
+    end
+
+    test "partial map mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      refute Mock.called?(MockTarget.example(%{c: 3}))
+    end
+
+    test "exact map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.called?(MockTarget.example(%{a: 1, b: 2}))
+      assert Mock.called?(MockTarget.example(%{b: 2, a: 1}))
+    end
+
+    test "exact match extra key mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      refute Mock.called?(MockTarget.example(%{a: 1, b: 2, c: 3}))
+    end
+
+    test "arbitrary complexity match" do
+      spy(MockTarget)
+
+      MockTarget.example([1, 2, 3, %{a: 1, b: 2}])
+
+      x = 1
+      assert Mock.called?(MockTarget.example([^x, y, _, %{a: 1}]))
+    end
+  end
+
+  describe "called?/1 with multiple calls" do
+    test "exact match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.called?(MockTarget.example(:a))
+      assert Mock.called?(MockTarget.example(:b))
+      assert Mock.called?(MockTarget.example(:c))
+    end
+
+    test "exact mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      refute Mock.called?(MockTarget.example(:d))
+      refute Mock.called?(MockTarget.example(:e))
+      refute Mock.called?(MockTarget.example(:f))
+    end
+
+    test "variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.called?(MockTarget.example(variable))
+    end
+
+    test "variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      MockTarget.example(variable_a)
+      MockTarget.example(variable_b)
+      MockTarget.example(variable_c)
+
+      assert Mock.called?(MockTarget.example(^variable_a))
+      assert Mock.called?(MockTarget.example(^variable_b))
+      assert Mock.called?(MockTarget.example(^variable_c))
+    end
+
+    test "other variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      argument_a = :a
+      argument_b = :b
+      argument_c = :c
+
+      MockTarget.example(argument_a)
+      MockTarget.example(argument_b)
+      MockTarget.example(argument_c)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      assert Mock.called?(MockTarget.example(^variable_a))
+      assert Mock.called?(MockTarget.example(^variable_b))
+      assert Mock.called?(MockTarget.example(^variable_c))
+    end
+
+    test "literal argument, pinned variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      assert Mock.called?(MockTarget.example(^variable_a))
+      assert Mock.called?(MockTarget.example(^variable_b))
+      assert Mock.called?(MockTarget.example(^variable_c))
+    end
+
+    test "wildcard match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.called?(MockTarget.example(_))
+    end
+
+    test "empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+
+      assert Mock.called?(MockTarget.example([]))
+    end
+
+    test "empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+      MockTarget.example([:a, :b, :c])
+
+      refute Mock.called?(MockTarget.example([]))
+    end
+
+    test "non-empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.called?(MockTarget.example([_ | _]))
+    end
+
+    test "non-empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+      MockTarget.example([])
+      MockTarget.example([])
+
+      refute Mock.called?(MockTarget.example([_ | _]))
+    end
+
+    test "empty map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.called?(MockTarget.example(%{}))
+    end
+
+    test "partial map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.called?(MockTarget.example(%{a: 1}))
+      assert Mock.called?(MockTarget.example(%{b: 2}))
+      assert Mock.called?(MockTarget.example(%{c: 3}))
+
+      assert Mock.called?(MockTarget.example(%{a: 1, b:  2}))
+      assert Mock.called?(MockTarget.example(%{b: 2, a:  1}))
+
+      assert Mock.called?(MockTarget.example(%{a: 1, c:  3}))
+      assert Mock.called?(MockTarget.example(%{c: 3, a:  1}))
+
+      assert Mock.called?(MockTarget.example(%{b: 2, c:  3}))
+      assert Mock.called?(MockTarget.example(%{c: 3, b:  2}))
+    end
+
+    test "partial map mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      refute Mock.called?(MockTarget.example(%{d: 4}))
+    end
+
+    test "exact map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.called?(MockTarget.example(%{a: 1}))
+      assert Mock.called?(MockTarget.example(%{a: 1, b: 2}))
+      assert Mock.called?(MockTarget.example(%{a: 1, b: 2, c: 3}))
+    end
+
+    test "exact match extra key mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      refute Mock.called?(MockTarget.example(%{a: 1, b: 2, c: 3}))
+    end
+
+    test "arbitrary complexity match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example([1, 2, 3, %{a: 1, b: 2}])
+
+      x = 1
+      assert Mock.called?(MockTarget.example([^x, y, _, %{a: 1}]))
+    end
+  end
+
+  describe "matches/1 with no calls" do
+    test "has no matching calls" do
+      spy(MockTarget)
+
+      assert Mock.matches(MockTarget.example(:test)) == []
+    end
+  end
+
+  describe "matches/1 with single call" do
+    test "exact match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.matches(MockTarget.example(:test)) == [
+        [:test]
+      ]
+    end
+
+    test "exact mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.matches(MockTarget.example(:other)) == []
+    end
+
+    test "variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.matches(MockTarget.example(variable)) == [
+        [:test]
+      ]
+    end
+
+    test "variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      variable = :test
+
+      MockTarget.example(variable)
+
+      assert Mock.matches(MockTarget.example(^variable)) == [
+        [:test]
+      ]
+    end
+
+    test "other variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      argument = :test
+      MockTarget.example(argument)
+
+      variable = :test
+      assert Mock.matches(MockTarget.example(^variable)) == [
+        [:test]
+      ]
+    end
+
+    test "literal argument, pinned variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      variable = :test
+      assert Mock.matches(MockTarget.example(^variable)) == [
+        [:test]
+      ]
+    end
+
+    test "wildcard match" do
+      spy(MockTarget)
+
+      MockTarget.example(:test)
+
+      assert Mock.matches(MockTarget.example(_)) == [
+        [:test]
+      ]
+    end
+
+    test "empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+
+      assert Mock.matches(MockTarget.example([])) == [
+        [[]]
+      ]
+    end
+
+    test "empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.matches(MockTarget.example([])) == []
+    end
+
+    test "non-empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.matches(MockTarget.example([_ | _])) == [
+        [[:a, :b, :c]]
+      ]
+    end
+
+    test "non-empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+
+      assert Mock.matches(MockTarget.example([_ | _])) == []
+    end
+
+    test "empty map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{})) == [
+        [%{a: 1, b: 2}]
+      ]
+    end
+
+    test "partial map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{a: 1})) == [
+        [%{a: 1, b: 2}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{b: 2})) == [
+        [%{a: 1, b: 2}]
+      ]
+    end
+
+    test "partial map mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{c: 3})) == []
+    end
+
+    test "exact map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b: 2})) == [
+        [%{a: 1, b: 2}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{b: 2, a: 1})) == [
+        [%{a: 1, b: 2}]
+      ]
+    end
+
+    test "exact match extra key mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b: 2, c: 3})) == []
+    end
+
+    test "arbitrary complexity match" do
+      spy(MockTarget)
+
+      MockTarget.example([1, 2, 3, %{a: 1, b: 2}])
+
+      x = 1
+      assert Mock.matches(MockTarget.example([^x, y, _, %{a: 1}])) == [
+        [[1, 2, 3, %{a: 1, b: 2}]]
+      ]
+    end
+  end
+
+  describe "matches/1 with multiple calls" do
+    test "exact match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.matches(MockTarget.example(:a)) == [
+        [:a]
+      ]
+
+      assert Mock.matches(MockTarget.example(:b)) == [
+        [:b]
+      ]
+
+      assert Mock.matches(MockTarget.example(:c)) == [
+        [:c]
+      ]
+    end
+
+    test "exact mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.matches(MockTarget.example(:d)) == []
+      assert Mock.matches(MockTarget.example(:e)) == []
+      assert Mock.matches(MockTarget.example(:f)) == []
+    end
+
+    test "variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.matches(MockTarget.example(variable)) == [
+        [:c],
+        [:b],
+        [:a]
+      ]
+    end
+
+    test "variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      MockTarget.example(variable_a)
+      MockTarget.example(variable_b)
+      MockTarget.example(variable_c)
+
+      assert Mock.matches(MockTarget.example(^variable_a)) == [
+        [:a]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_b)) == [
+        [:b]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_c)) == [
+        [:c]
+      ]
+    end
+
+    test "other variable argument, pinned variable match" do
+      spy(MockTarget)
+
+      argument_a = :a
+      argument_b = :b
+      argument_c = :c
+
+      MockTarget.example(argument_a)
+      MockTarget.example(argument_b)
+      MockTarget.example(argument_c)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      assert Mock.matches(MockTarget.example(^variable_a)) == [
+        [:a]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_b)) == [
+        [:b]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_c)) == [
+        [:c]
+      ]
+    end
+
+    test "literal argument, pinned variable match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      variable_a = :a
+      variable_b = :b
+      variable_c = :c
+
+      assert Mock.matches(MockTarget.example(^variable_a)) == [
+        [:a]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_b)) == [
+        [:b]
+      ]
+
+      assert Mock.matches(MockTarget.example(^variable_c)) == [
+        [:c]
+      ]
+    end
+
+    test "wildcard match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example(:c)
+
+      assert Mock.matches(MockTarget.example(_)) == [
+        [:c],
+        [:b],
+        [:a]
+      ]
+    end
+
+    test "empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+
+      assert Mock.matches(MockTarget.example([])) == [
+        [[]]
+      ]
+    end
+
+    test "empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.matches(MockTarget.example([])) == []
+    end
+
+    test "non-empty list match" do
+      spy(MockTarget)
+
+      MockTarget.example([:a])
+      MockTarget.example([:a, :b])
+      MockTarget.example([:a, :b, :c])
+
+      assert Mock.matches(MockTarget.example([_ | _])) == [
+        [[:a, :b, :c]],
+        [[:a, :b]],
+        [[:a]]
+      ]
+    end
+
+    test "non-empty list mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example([])
+      MockTarget.example([])
+      MockTarget.example([])
+
+      assert Mock.matches(MockTarget.example([_ | _])) == []
+    end
+
+    test "empty map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.matches(MockTarget.example(%{})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}],
+        [%{a: 1}]
+      ]
+    end
+
+    test "partial map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.matches(MockTarget.example(%{a: 1})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}],
+        [%{a: 1}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{b: 2})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{c: 3})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b:  2})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{b: 2, a:  1})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{a: 1, c:  3})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{c: 3, a:  1})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{b: 2, c:  3})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{c: 3, b:  2})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+    end
+
+    test "partial map mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.matches(MockTarget.example(%{d: 4})) == []
+    end
+
+    test "exact map match" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1})
+      MockTarget.example(%{a: 1, b: 2})
+      MockTarget.example(%{a: 1, b: 2, c: 3})
+
+      assert Mock.matches(MockTarget.example(%{a: 1})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}],
+        [%{a: 1}]
+      ]
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b: 2})) == [
+        [%{a: 1, b: 2, c: 3}],
+        [%{a: 1, b: 2}],
+      ]
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b: 2, c: 3})) == [
+        [%{a: 1, b: 2, c: 3}]
+      ]
+    end
+
+    test "exact match extra key mismatch" do
+      spy(MockTarget)
+
+      MockTarget.example(%{a: 1, b: 2})
+
+      assert Mock.matches(MockTarget.example(%{a: 1, b: 2, c: 3})) == []
+    end
+
+    test "arbitrary complexity match" do
+      spy(MockTarget)
+
+      MockTarget.example(:a)
+      MockTarget.example(:b)
+      MockTarget.example([1, 2, 3, %{a: 1, b: 2}])
+
+      x = 1
+      assert Mock.matches(MockTarget.example([^x, y, _, %{a: 1}])) == [
+        [[1, 2, 3, %{a: 1, b: 2}]]
+      ]
+    end
+  end
+
+end

--- a/test/user/assert_called_once_test.exs
+++ b/test/user/assert_called_once_test.exs
@@ -39,8 +39,8 @@ defmodule Patch.Test.User.AssertCalledOnecTest do
 
       assert AssertCalledOnce.example(1, 2) == :patched
 
-      assert_called_once AssertCalledOnce.example(1, :_)
-      assert_called_once AssertCalledOnce.example(:_, 2)
+      assert_called_once AssertCalledOnce.example(1, _)
+      assert_called_once AssertCalledOnce.example(_, 2)
     end
 
     test "partial call mismatch raises MissingCall" do
@@ -49,11 +49,11 @@ defmodule Patch.Test.User.AssertCalledOnecTest do
       assert AssertCalledOnce.example(1, 2) == :patched
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called_once AssertCalledOnce.example(3, :_)
+        assert_called_once AssertCalledOnce.example(3, _)
       end
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called_once AssertCalledOnce.example(:_, 4)
+        assert_called_once AssertCalledOnce.example(_, 4)
       end
     end
 
@@ -66,11 +66,11 @@ defmodule Patch.Test.User.AssertCalledOnecTest do
 
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called_once AssertCalledOnce.example(1, :_)
+        assert_called_once AssertCalledOnce.example(1, _)
       end
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called_once AssertCalledOnce.example(:_, 2)
+        assert_called_once AssertCalledOnce.example(_, 2)
       end
     end
 
@@ -79,14 +79,14 @@ defmodule Patch.Test.User.AssertCalledOnecTest do
 
       assert AssertCalledOnce.example(1, 2) == :patched
 
-      assert_called_once AssertCalledOnce.example(:_, :_)
+      assert_called_once AssertCalledOnce.example(_, _)
     end
 
     test "wildcard call raises MissingCall when no calls present" do
       patch(AssertCalledOnce, :example, :patched)
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called_once AssertCalledOnce.example(:_, :_)
+        assert_called_once AssertCalledOnce.example(_, _)
       end
     end
 
@@ -97,7 +97,7 @@ defmodule Patch.Test.User.AssertCalledOnecTest do
       assert AssertCalledOnce.example(3, 4) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called_once AssertCalledOnce.example(:_, :_)
+        assert_called_once AssertCalledOnce.example(_, _)
       end
     end
 

--- a/test/user/assert_called_test.exs
+++ b/test/user/assert_called_test.exs
@@ -28,8 +28,8 @@ defmodule Patch.Test.User.AssertCalledTest do
 
       assert AssertCalled.example(1, 2) == :patched
 
-      assert_called AssertCalled.example(1, :_)
-      assert_called AssertCalled.example(:_, 2)
+      assert_called AssertCalled.example(1, _)
+      assert_called AssertCalled.example(_, 2)
     end
 
     test "partial call mismatch raises MissingCall" do
@@ -38,11 +38,11 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(1, 2) == :patched
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(3, :_)
+        assert_called AssertCalled.example(3, _)
       end
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(:_, 4)
+        assert_called AssertCalled.example(_, 4)
       end
     end
 
@@ -51,15 +51,47 @@ defmodule Patch.Test.User.AssertCalledTest do
 
       assert AssertCalled.example(1, 2) == :patched
 
-      assert_called AssertCalled.example(:_, :_)
+      assert_called AssertCalled.example(_, _)
     end
 
     test "wildcard call raises MissingCall when no calls present" do
       patch(AssertCalled, :example, :patched)
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(:_, :_)
+        assert_called AssertCalled.example(_, _)
       end
+    end
+
+    test "variable match" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(a, b)
+
+      assert a == 1
+      assert b == 2
+    end
+
+    test "partial map match" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(%{a: 1, b: 2}, :test) == :patched
+
+      assert_called AssertCalled.example(%{a: 1}, _)
+    end
+
+    test "patterns can express arbitrary complexity" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example([1, 2, 3, %{a: 1, b: 2}], []) == :patched
+
+      x = 1
+
+      assert_called AssertCalled.example([^x, y, _z, %{b: 2}] = first, [])
+
+      assert first == [1, 2, 3, %{a: 1, b: 2}]
+      assert y == 2
     end
 
     test "exception formatting with no calls" do
@@ -166,13 +198,13 @@ defmodule Patch.Test.User.AssertCalledTest do
 
       assert AssertCalled.example(1, 2) == :patched
 
-      assert_called AssertCalled.example(1, :_), 1
-      assert_called AssertCalled.example(:_, 2), 1
+      assert_called AssertCalled.example(1, _), 1
+      assert_called AssertCalled.example(_, 2), 1
 
       assert AssertCalled.example(1, 2) == :patched
 
-      assert_called AssertCalled.example(1, :_), 2
-      assert_called AssertCalled.example(:_, 2), 2
+      assert_called AssertCalled.example(1, _), 2
+      assert_called AssertCalled.example(_, 2), 2
     end
 
     test "partial call mismatch raises MissingCall" do
@@ -181,11 +213,11 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(1, 2) == :patched
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(3, :_), 1
+        assert_called AssertCalled.example(3, _), 1
       end
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(:_, 4), 1
+        assert_called AssertCalled.example(_, 4), 1
       end
     end
 
@@ -195,11 +227,11 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(1, 2) == :patched
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(1, :_), 2
+        assert_called AssertCalled.example(1, _), 2
       end
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(:_, 2), 2
+        assert_called AssertCalled.example(_, 2), 2
       end
     end
 
@@ -211,11 +243,11 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(3, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called AssertCalled.example(1, :_), 1
+        assert_called AssertCalled.example(1, _), 1
       end
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called AssertCalled.example(:_, 2), 1
+        assert_called AssertCalled.example(_, 2), 1
       end
     end
 
@@ -224,11 +256,11 @@ defmodule Patch.Test.User.AssertCalledTest do
 
       assert AssertCalled.example(1, 2) == :patched
 
-      assert_called AssertCalled.example(:_, :_), 1
+      assert_called AssertCalled.example(_, _), 1
 
       assert AssertCalled.example(3, 4) == :patched
 
-      assert_called AssertCalled.example(:_, :_), 2
+      assert_called AssertCalled.example(_, _), 2
     end
 
     test "wildcard call with too high an expected count raises MissingCall" do
@@ -237,7 +269,7 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(1, 2) == :patched
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called AssertCalled.example(:_, :_), 2
+        assert_called AssertCalled.example(_, _), 2
       end
     end
 
@@ -248,8 +280,42 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert AssertCalled.example(3, 4) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        assert_called AssertCalled.example(:_, :_), 1
+        assert_called AssertCalled.example(_, _), 1
       end
+    end
+
+    test "variable matches only call" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(a, b), 1
+
+      assert a == 1
+      assert b == 2
+    end
+
+    test "variable matches latest call" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(3, 4) == :patched
+
+      assert_called AssertCalled.example(a, b), 2
+
+      assert a == 3
+      assert b == 4
+    end
+
+    test "pattern match matches latest call" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(1, 3) == :patched
+
+      assert_called AssertCalled.example(1, a), 2
+
+      assert a == 3
     end
 
     test "exception formatting with no calls" do

--- a/test/user/assert_called_test.exs
+++ b/test/user/assert_called_test.exs
@@ -382,5 +382,32 @@ defmodule Patch.Test.User.AssertCalledTest do
         assert_called AssertCalled.example(1, 2), 1
       end
     end
+
+    test "exception formatting with wrong pinned variables" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+      assert AssertCalled.example(1, 3) == :patched
+      assert AssertCalled.example(1, 4) == :patched
+
+      x = 1
+
+      expected_message = """
+      \n
+      Expected 1 of the following calls, but found 0:
+
+        Patch.Test.Support.User.AssertCalled.example(1, ^x)
+
+      Calls which were received (matching calls are marked with *):
+
+        1. Patch.Test.Support.User.AssertCalled.example(1, 2)
+        2. Patch.Test.Support.User.AssertCalled.example(1, 3)
+        3. Patch.Test.Support.User.AssertCalled.example(1, 4)
+      """
+
+      assert_raise Patch.MissingCall, expected_message, fn ->
+        assert_called AssertCalled.example(1, ^x), 1
+      end
+    end
   end
 end

--- a/test/user/patch/local_call_test.exs
+++ b/test/user/patch/local_call_test.exs
@@ -28,7 +28,7 @@ defmodule Patch.Test.User.Patch.LocalCallTest do
 
       patch(LocalCall, :public_function, :patched)
 
-      refute_called LocalCall.public_function(:_)
+      refute_called LocalCall.public_function(_)
     end
   end
 
@@ -56,7 +56,7 @@ defmodule Patch.Test.User.Patch.LocalCallTest do
 
       patch(LocalCall, :private_function, :patched)
 
-      refute_called LocalCall.private_function(:_)
+      refute_called LocalCall.private_function(_)
     end
   end
 end

--- a/test/user/refute_called_once_test.exs
+++ b/test/user/refute_called_once_test.exs
@@ -37,8 +37,8 @@ defmodule Patch.Test.User.RefuteCalledOnecTest do
 
       assert RefuteCalledOnce.example(1, 2) == :patched
 
-      refute_called_once RefuteCalledOnce.example(3, :_)
-      refute_called_once RefuteCalledOnce.example(:_, 4)
+      refute_called_once RefuteCalledOnce.example(3, _)
+      refute_called_once RefuteCalledOnce.example(_, 4)
     end
 
     test "partial call that match raises UnexpectedCall" do
@@ -47,11 +47,11 @@ defmodule Patch.Test.User.RefuteCalledOnecTest do
       assert RefuteCalledOnce.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called_once RefuteCalledOnce.example(1, :_)
+        refute_called_once RefuteCalledOnce.example(1, _)
       end
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called_once RefuteCalledOnce.example(:_, 2)
+        refute_called_once RefuteCalledOnce.example(_, 2)
       end
     end
 
@@ -62,14 +62,14 @@ defmodule Patch.Test.User.RefuteCalledOnecTest do
       assert RefuteCalledOnce.example(1, 3) == :patched
       assert RefuteCalledOnce.example(3, 2) == :patched
 
-      refute_called_once RefuteCalledOnce.example(1, :_)
-      refute_called_once RefuteCalledOnce.example(:_, 2)
+      refute_called_once RefuteCalledOnce.example(1, _)
+      refute_called_once RefuteCalledOnce.example(_, 2)
     end
 
     test "an uncalled function can be wildcard refuted" do
       patch(RefuteCalledOnce, :example, :patched)
 
-      refute_called_once RefuteCalledOnce.example(:_, :_)
+      refute_called_once RefuteCalledOnce.example(_, _)
     end
 
     test "any call causes a wildcard to raise UnexpectedCall" do
@@ -78,7 +78,7 @@ defmodule Patch.Test.User.RefuteCalledOnecTest do
       assert RefuteCalledOnce.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called_once RefuteCalledOnce.example(:_, :_)
+        refute_called_once RefuteCalledOnce.example(_, _)
       end
     end
 
@@ -88,7 +88,7 @@ defmodule Patch.Test.User.RefuteCalledOnecTest do
       assert RefuteCalledOnce.example(1, 2) == :patched
       assert RefuteCalledOnce.example(3, 4) == :patched
 
-      refute_called_once RefuteCalledOnce.example(:_, :_)
+      refute_called_once RefuteCalledOnce.example(_, _)
     end
 
     test "exception formatting" do

--- a/test/user/refute_called_test.exs
+++ b/test/user/refute_called_test.exs
@@ -28,8 +28,8 @@ defmodule Patch.Test.User.RefuteCalledTest do
 
       assert RefuteCalled.example(1, 2) == :patched
 
-      refute_called RefuteCalled.example(3, :_)
-      refute_called RefuteCalled.example(:_, 4)
+      refute_called RefuteCalled.example(3, _)
+      refute_called RefuteCalled.example(_, 4)
     end
 
     test "partial calls that match raises UnexpectedCall" do
@@ -38,18 +38,18 @@ defmodule Patch.Test.User.RefuteCalledTest do
       assert RefuteCalled.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(1, :_)
+        refute_called RefuteCalled.example(1, _)
       end
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(:_, 2)
+        refute_called RefuteCalled.example(_, 2)
       end
     end
 
     test "an uncalled function can be wildcard refuted" do
       patch(RefuteCalled, :example, :patched)
 
-      refute_called RefuteCalled.example(:_, :_)
+      refute_called RefuteCalled.example(_, _)
     end
 
     test "any call causes a wildcard refute to raise UnexpectedCall" do
@@ -58,7 +58,7 @@ defmodule Patch.Test.User.RefuteCalledTest do
       assert RefuteCalled.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(:_, :_)
+        refute_called RefuteCalled.example(_, _)
       end
     end
 
@@ -130,8 +130,8 @@ defmodule Patch.Test.User.RefuteCalledTest do
 
       assert RefuteCalled.example(1, 2) == :patched
 
-      refute_called RefuteCalled.example(1, :_), 2
-      refute_called RefuteCalled.example(:_, 2), 2
+      refute_called RefuteCalled.example(1, _), 2
+      refute_called RefuteCalled.example(_, 2), 2
     end
 
     test "partial call can be refuted with expression count" do
@@ -141,8 +141,8 @@ defmodule Patch.Test.User.RefuteCalledTest do
 
       unexpected_count = 2
 
-      refute_called RefuteCalled.example(1, :_), unexpected_count
-      refute_called RefuteCalled.example(:_, 2), unexpected_count + 1
+      refute_called RefuteCalled.example(1, _), unexpected_count
+      refute_called RefuteCalled.example(_, 2), unexpected_count + 1
     end
 
     test "partial calls that match raises UnexpectedCall" do
@@ -151,18 +151,18 @@ defmodule Patch.Test.User.RefuteCalledTest do
       assert RefuteCalled.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(1, :_), 1
+        refute_called RefuteCalled.example(1, _), 1
       end
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(:_, 2), 1
+        refute_called RefuteCalled.example(_, 2), 1
       end
     end
 
     test "an uncalled function can be wildcard refuted" do
       patch(RefuteCalled, :example, :patched)
 
-      refute_called RefuteCalled.example(:_, :_), 1
+      refute_called RefuteCalled.example(_, _), 1
     end
 
     test "any call causes a wildcard refute to raise UnexpectedCall" do
@@ -171,7 +171,7 @@ defmodule Patch.Test.User.RefuteCalledTest do
       assert RefuteCalled.example(1, 2) == :patched
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called RefuteCalled.example(:_, :_), 1
+        refute_called RefuteCalled.example(_, _), 1
       end
     end
 

--- a/test/user/spy_test.exs
+++ b/test/user/spy_test.exs
@@ -53,7 +53,7 @@ defmodule Patch.Test.User.SpyTest do
 
       assert Spy.example(:test_argument_2) == {:original, :test_argument_2}
 
-      assert_called Spy.example(:_)
+      assert_called Spy.example(_)
     end
 
     test "raises MissingCall if no calls have occurred on assert_called with wildcard" do
@@ -62,7 +62,7 @@ defmodule Patch.Test.User.SpyTest do
       spy(Spy)
 
       assert_raise Patch.MissingCall, fn ->
-        assert_called Spy.example(:_)
+        assert_called Spy.example(_)
       end
     end
 
@@ -94,7 +94,7 @@ defmodule Patch.Test.User.SpyTest do
 
       spy(Spy)
 
-      refute_called Spy.example(:_)
+      refute_called Spy.example(_)
     end
 
     test "raises UnexpectedCall for refute_called with wildcards if any call to the spy has occurred" do
@@ -105,7 +105,7 @@ defmodule Patch.Test.User.SpyTest do
       assert Spy.example(:test_argument_2) == {:original, :test_argument_2}
 
       assert_raise Patch.UnexpectedCall, fn ->
-        refute_called Spy.example(:_)
+        refute_called Spy.example(_)
       end
     end
   end


### PR DESCRIPTION
Replaces the ad-hoc pattern matching in the following functions with true pattern matching via macros.

- `assert_called/1`
- `assert_called/2`
- `assert_called_once/1`
- `refute_called/1`
- `refute_called/2`
- `refute_called_once/1`

`assert_called/1,2` and `assert_called_once/1` use non-hygienic binds similar to how `assert_receive/1` and `assert_received/1` works.

This allows test authors to write code like this.

```elixir
test "example test" do
  patch(Example, :function, :patched)

  assert Example.function(1, 2, 3) == :patched

  x = 1
  assert_called Example.function(^x, y, _)

  assert y == 2
end
```

Resolves #17 