### PR TITLE
Improve expose/2 and private/1 documentation

### DIFF
--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -193,6 +193,10 @@ defmodule Patch do
   ```elixir
   expose(Example, [private_function: 1, private_function: 2])
   ```
+
+  After exposing a function, attempting to call the exposed function will cause the Elixir
+  Compiler to flag calls to exposed functions as a warning.  There is a companion macro
+  `private/1` that test authors can wrap their calls with to prevent warnings.
   """
   @spec expose(module :: module, exposes :: Patch.Mock.exposes()) :: :ok | {:error, term()}
   def expose(module, exposes) do
@@ -460,8 +464,9 @@ defmodule Patch do
   @doc """
   Suppress warnings for using exposed private functions in tests.
 
-  Patch allows you to make a private function public, but this happens dynamically at test time.
-  The Elixir Compiler will flag calls to exposed functions as a warning.
+  Patch allows you to make a private function public via the `expose/2` function.  Exposure
+  happens dynamically at test time. The Elixir Compiler will flag calls to exposed functions as a
+  warning.
 
   One way around this is to change the normal function call into an `apply/3` but this is
   cumbersome and makes tests harder to read.

--- a/pages/super-powers.md
+++ b/pages/super-powers.md
@@ -194,7 +194,9 @@ Testing `public_function/1` gives us a very coarse measure of if the `private_fu
 
 It would be great if we could expose `private_function/1` to be able to more directly test this unit. 
 
-Here's how we can expose this function for testing via `expose/2`
+Here's how we can expose this function for testing via `expose/2`.  Calling an exposed functions will be flagged by the 
+Elixir Compiler as a warning, since the exposure happens at runtime not compile-time.  To suppress these warnings, the
+`private/1` macro is provided, just wrap the call to the exposed function with `private/1`.
 
 ```elixir
 defmodule ExampleTest do
@@ -205,19 +207,19 @@ defmodule ExampleTest do
     test "values less than 20 get magnified by 1000" do
       expose(Example, private_function: 1)
 
-      assert Example.private_function(10) == 10_000
+      assert private(Example.private_function(10)) == 10_000
     end
 
     test "values betwen 20 and 80 are reduced by 3" do
       expose(Example, private_function: 1)
 
-      assert Example.private_function(50) == 47
+      assert private(Example.private_function(50)) == 47
     end
 
     test "values greater than or equal to 80 are halved" do
       expose(Example, private_function: 1)
 
-      assert Example.private_function(120) == 60
+      assert private(Example.private_function(120)) == 60
     end
   end
 end


### PR DESCRIPTION
Using expose/2 without private/1 is a recipe for lots of compiler
warnings.

Cross reference these two functions to improve discoverability

Resolves #19 