### PR TITLE
Fix a bug in the compile attribute cleaner

### DIFF
--- a/lib/patch/mock/code/transforms/clean.ex
+++ b/lib/patch/mock/code/transforms/clean.ex
@@ -13,24 +13,59 @@ defmodule Patch.Mock.Code.Transforms.Clean do
 
   @spec transform(abstract_forms :: [Code.form()]) :: [Code.form()]
   def transform(abstract_forms) do
-    Enum.filter(abstract_forms, fn
-      {:attribute, _, :module, _} ->
+    abstract_forms
+    |> Enum.reduce([], fn
+      {:attribute, _, :module, _} = form, acc ->
+        [form | acc]
+
+      {:attribute, _, :export, _} = form, acc ->
+        [form | acc]
+
+      {:attribute, anno, :compile, options}, acc ->
+        case filter_compile_options(options) do
+          [] ->
+            acc
+
+          options ->
+            form = {:attribute, anno, :compile, options}
+            [form | acc]
+        end
+
+      {:function, _, _, _, _} = form, acc ->
+        [form | acc]
+
+      _, acc ->
+        acc
+    end)
+    |> Enum.reverse()
+  end
+
+  ## Private Functions
+
+  @spec filter_compile_options(option :: term()) :: term()
+  defp filter_compile_options(:no_auto_import) do
+    :no_auto_import
+  end
+
+  defp filter_compile_options({:no_auto_import, _} = option)  do
+    option
+  end
+
+  @spec filter_compile_options(options :: [term()]) :: [term()]
+  defp filter_compile_options(options) when is_list(options) do
+    Enum.filter(options, fn
+      :no_auto_import ->
         true
 
-      {:attribute, _, :export, _} ->
-        true
-
-      {:attribute, _, :compile, [:no_auto_import]} ->
-        true
-
-      {:attribute, _, :compile, [:no_auto_import, _]} ->
-        true
-
-      {:function, _, _, _, _} ->
+      {:no_auto_import, _} ->
         true
 
       _ ->
         false
     end)
+  end
+
+  defp filter_compile_options(_) do
+    []
   end
 end

--- a/test/unit/patch/mock/code/transforms/clean_test.exs
+++ b/test/unit/patch/mock/code/transforms/clean_test.exs
@@ -1,0 +1,79 @@
+defmodule Patch.Test.Unit.Patch.Mock.Code.Transforms.CleanTest do
+  use ExUnit.Case
+
+  alias Patch.Mock.Code.Transforms.Clean
+
+  describe "transform/1 compile attribute handling" do
+    test "retains wildcard no_auto_import when expressed as scalar" do
+      forms = [
+        {:attribute, 1, :compile, :no_auto_import}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == forms
+    end
+
+    test "retains wildcard no_auto_import when expressed as list" do
+      forms = [
+        {:attribute, 1, :compile, [:no_auto_import]}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == forms
+    end
+
+    test "retains specific no_auto_import when expressed as scalar" do
+      forms = [
+        {:attribute, 1, :compile, {:no_auto_import, [example: 1]}}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == forms
+    end
+
+    test "retains specific no_auto_import when expressed as list" do
+      forms = [
+        {:attribute, 1, :compile, [no_auto_import: [example: 1]]}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == forms
+    end
+
+    test "strips other options" do
+      forms = [
+        {:attribute, 1, :compile, [:no_auto_import, {:inline, [example: 1]}]}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == [
+        {:attribute, 1, :compile, [:no_auto_import]}
+      ]
+    end
+
+    test "removes attribute entirely if no valid options expressed as scalar" do
+      forms = [
+        {:attribute, 1, :compile, {:inline, [example: 1]}}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == []
+    end
+
+    test "removes attribute entirely if no valid options expressed as list" do
+      forms = [
+        {:attribute, 1, :compile, [{:inline, [example: 1]}]}
+      ]
+
+      cleaned = Clean.transform(forms)
+
+      assert cleaned == []
+    end
+  end
+end


### PR DESCRIPTION
Abstract form can collapse multiple `-compile` attributes into a single
form.  Patch.Mock.Code.Transforms.Clean was retaining compile attributes
that it shouldn't.

There are now some tests and a new strategy for filtering the compile
attributes.