### PR TITLE
Passthrough behavior for functions.

### DIFF
--- a/lib/patch/apply.ex
+++ b/lib/patch/apply.ex
@@ -1,0 +1,30 @@
+defmodule Patch.Apply do
+  @moduledoc """
+  Utility module to assist with applying functions.
+  """
+
+  @doc """
+  Safe application of an anonymous function.
+
+  This is just like `apply/2` but if the the anonymous function is unable to
+  handle the call (raising either `BadArityError` or `FunctionClauseError`) then
+  the `:error` atom is returned.
+
+  If the function evaluates successfully its reply is returned wrapped in an
+  `{:ok, result}` tuple.
+  """
+  @spec safe(function :: function(), arguments :: [term()]) :: {:ok, term()} | :error
+  def safe(function, arguments) do
+    try do
+      result = apply(function, arguments)
+
+      {:ok, result}
+    rescue
+      BadArityError ->
+        :error
+
+      FunctionClauseError ->
+        :error
+    end
+  end
+end

--- a/lib/patch/mock/server.ex
+++ b/lib/patch/mock/server.ex
@@ -236,8 +236,14 @@ defmodule Patch.Mock.Server do
     with {:ok, value} <- Map.fetch(state.mocks, name) do
       {next, reply} =
         try do
-          {next, reply} = Value.next(value, arguments)
-          {next, {:ok, reply}}
+          case Value.next(value, arguments) do
+            {:ok, next, reply} ->
+              {next, {:ok, reply}}
+
+            :error ->
+              next = Value.advance(value)
+              {next, :error}
+          end
         rescue
           exception ->
             next = Value.advance(value)

--- a/lib/patch/mock/values/callable.ex
+++ b/lib/patch/mock/values/callable.ex
@@ -1,4 +1,6 @@
 defmodule Patch.Mock.Values.Callable do
+  alias Patch.Apply
+
   @type dispatch_mode :: :apply | :list
 
   @type t :: %__MODULE__{
@@ -17,12 +19,16 @@ defmodule Patch.Mock.Values.Callable do
     %__MODULE__{dispatch: dispatch, target: target}
   end
 
-  @spec next(callable :: t(), arguments :: [term()]) :: {t(), term()}
+  @spec next(callable :: t(), arguments :: [term()]) :: {:ok, t(), term()} | :error
   def next(%__MODULE__{dispatch: :apply} = callable, arguments) do
-    {callable, apply(callable.target, arguments)}
+    with {:ok, result} <- Apply.safe(callable.target, arguments) do
+      {:ok, callable, result}
+    end
   end
 
   def next(%__MODULE__{dispatch: :list} = callable, arguments) do
-    {callable, apply(callable.target, [arguments])}
+    with {:ok, result} <- Apply.safe(callable.target, [arguments]) do
+      {:ok, callable, result}
+    end
   end
 end

--- a/lib/patch/mock/values/cycle.ex
+++ b/lib/patch/mock/values/cycle.ex
@@ -21,17 +21,17 @@ defmodule Patch.Mock.Values.Cycle do
     %__MODULE__{values: values}
   end
 
-  @spec next(t(), arguments :: [term()]) :: {t(), term()}
+  @spec next(t(), arguments :: [term()]) :: {:ok, t(), term()} | :error
   def next(%__MODULE__{values: []} = cycle, _arguments) do
-    {cycle, nil}
+    {:ok, cycle, nil}
   end
 
   def next(%__MODULE__{values: [value]} = cycle, _arguments) do
-    {cycle, value}
+    {:ok, cycle, value}
   end
 
   def next(%__MODULE__{values: [head | rest]} = cycle, _arguments) do
     cycle = %__MODULE__{cycle | values: rest ++ [head]}
-    {cycle, head}
+    {:ok, cycle, head}
   end
 end

--- a/lib/patch/mock/values/raises.ex
+++ b/lib/patch/mock/values/raises.ex
@@ -1,0 +1,27 @@
+defmodule Patch.Mock.Values.Raises do
+  @type t :: %__MODULE__{
+          exception: module(),
+          attributes: Keyword.t()
+        }
+  defstruct [:exception, :attributes]
+
+  @spec advance(raises :: t()) :: t()
+  def advance(%__MODULE__{} = raises) do
+    raises
+  end
+
+  @spec new(message :: String.t()) :: t()
+  def new(message) do
+    new(RuntimeError, message: message)
+  end
+
+  @spec new(exception :: module(), attributes :: Keyword.t()) :: t()
+  def new(exception, attributes) do
+    %__MODULE__{exception: exception, attributes: attributes}
+  end
+
+  @spec next(raises :: t(), arguments :: [term()]) :: none()
+  def next(%__MODULE__{} = raises, _arguments) do
+    raise raises.exception, raises.attributes
+  end
+end

--- a/lib/patch/mock/values/scalar.ex
+++ b/lib/patch/mock/values/scalar.ex
@@ -14,8 +14,8 @@ defmodule Patch.Mock.Values.Scalar do
     %__MODULE__{value: scalar}
   end
 
-  @spec next(scalar :: t(), arguments :: [term()]) :: {t(), term()}
+  @spec next(scalar :: t(), arguments :: [term()]) :: {:ok, t(), term()} | :error
   def next(%__MODULE__{} = scalar, _arguments) do
-    {scalar, scalar.value}
+    {:ok, scalar, scalar.value}
   end
 end

--- a/lib/patch/mock/values/sequence.ex
+++ b/lib/patch/mock/values/sequence.ex
@@ -22,17 +22,17 @@ defmodule Patch.Mock.Values.Sequence do
     %__MODULE__{values: values}
   end
 
-  @spec next(sequence :: t(), arguments :: [term()]) :: {t(), term()}
+  @spec next(sequence :: t(), arguments :: [term()]) :: {:ok, t(), term()} | :error
   def next(%__MODULE__{values: []} = sequence, _arguments) do
-    {sequence, nil}
+    {:ok, sequence, nil}
   end
 
   def next(%__MODULE__{values: [last]} = sequence, _arguments) do
-    {sequence, last}
+    {:ok, sequence, last}
   end
 
   def next(%__MODULE__{values: [head | rest]} = sequence, _arguments) do
     sequence = %__MODULE__{sequence | values: rest}
-    {sequence, head}
+    {:ok, sequence, head}
   end
 end

--- a/lib/patch/mock/values/throws.ex
+++ b/lib/patch/mock/values/throws.ex
@@ -1,0 +1,21 @@
+defmodule Patch.Mock.Values.Throws do
+  @type t :: %__MODULE__{
+          value: term()
+        }
+  defstruct [:value]
+
+  @spec advance(throws :: t()) :: t()
+  def advance(%__MODULE__{} = throws) do
+    throws
+  end
+
+  @spec new(throws :: term()) :: t()
+  def new(throws) do
+    %__MODULE__{value: throws}
+  end
+
+  @spec next(throws :: t(), arguments :: [term()]) :: none()
+  def next(%__MODULE__{} = throws, _arguments) do
+    throw throws.value
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -104,11 +104,14 @@ defmodule Patch.MixProject do
           Patch.Mock.Value,
           Patch.Mock.Values.Callable,
           Patch.Mock.Values.Cycle,
+          Patch.Mock.Values.Raises,
           Patch.Mock.Values.Scalar,
           Patch.Mock.Values.Sequence,
+          Patch.Mock.Values.Throws
         ],
         "Utilities": [
           Patch.Access,
+          Patch.Apply,
           Patch.Assertions,
           Patch.Macro,
           Patch.Reflection,

--- a/test/user/patch/callable_test.exs
+++ b/test/user/patch/callable_test.exs
@@ -6,11 +6,11 @@ defmodule Patch.Test.User.Patch.CallableTest do
 
   describe "patch/3 with callable" do
     test "callable is evaluated" do
-      assert Callable.example(:test_argument) == {:original, :test_argument}
+      assert Callable.example(:a) == {:original, :a}
 
       patch(Callable, :example, fn _ -> :patched end)
 
-      assert Callable.example(:test_argument) == :patched
+      assert Callable.example(:a) == :patched
     end
 
     test "callable is dispatched with application by default" do
@@ -21,14 +21,23 @@ defmodule Patch.Test.User.Patch.CallableTest do
       assert Callable.example(:a, :b, :c) == {:patched, :a, :b, :c}
     end
 
-    test "in apply mode, calling the patched function with the wrong arity raises" do
+    test "in apply mode, calling the patched function with an existing but unpatched arity passes through to the original module" do
+      assert Callable.example(:a) == {:original, :a}
       assert Callable.example(:a, :b, :c) == {:original, :a, :b, :c}
 
       patch(Callable, :example, fn a, b, c -> {:patched, a, b, c} end)
 
-      assert_raise BadArityError, fn ->
-        Callable.example(:test_argument)
-      end
+      assert Callable.example(:a) == {:original, :a}
+    end
+
+    test "in apply mode, calling the patched function with arguments that do not match calls the original function" do
+      assert Callable.example(:a, :b, :c) == {:original, :a, :b, :c}
+
+      patch(Callable, :example, fn 1, b, c -> {:patched, 1, b, c} end)
+
+      assert Callable.example(:a, :b, :c) == {:original, :a, :b, :c}
+
+      assert Callable.example(1, :b, :c) == {:patched, 1, :b, :c}
     end
 
     test "callable can optionally be dispatched with all arguments in a list" do
@@ -42,7 +51,7 @@ defmodule Patch.Test.User.Patch.CallableTest do
     end
 
     test "callable can cover multiple arities using list dispatch" do
-      assert Callable.example(:test_argument) == {:original, :test_argument}
+      assert Callable.example(:a) == {:original, :a}
 
       callable = callable(fn
         [a] ->
@@ -54,32 +63,32 @@ defmodule Patch.Test.User.Patch.CallableTest do
 
       patch(Callable, :example, callable)
 
-      assert Callable.example(:test_argument) == {:arity_1, :test_argument}
+      assert Callable.example(:a) == {:arity_1, :a}
       assert Callable.example(:a, :b, :c) == {:arity_3, :a, :b, :c}
     end
 
     test "can be embedded in a cycle" do
-      assert Callable.example(:test_argument) == {:original, :test_argument}
+      assert Callable.example(:a) == {:original, :a}
 
       patch(Callable, :example, cycle([1, fn arg -> {2, arg} end, 3]))
 
-      assert Callable.example(:test_argument_1) == 1
-      assert Callable.example(:test_argument_1) == {2, :test_argument_1}
-      assert Callable.example(:test_argument_1) == 3
-      assert Callable.example(:test_argument_2) == 1
-      assert Callable.example(:test_argument_2) == {2, :test_argument_2}
-      assert Callable.example(:test_argument_2) == 3
+      assert Callable.example(:a) == 1
+      assert Callable.example(:a) == {2, :a}
+      assert Callable.example(:a) == 3
+      assert Callable.example(:b) == 1
+      assert Callable.example(:b) == {2, :b}
+      assert Callable.example(:b) == 3
     end
 
     test "can be embedded in a sequence" do
-      assert Callable.example(:test_argument) == {:original, :test_argument}
+      assert Callable.example(:a) == {:original, :a}
 
       patch(Callable, :example, sequence([1, fn arg -> {2, arg} end, fn arg -> {3, arg} end]))
 
-      assert Callable.example(:test_argument_1) == 1
-      assert Callable.example(:test_argument_1) == {2, :test_argument_1}
-      assert Callable.example(:test_argument_1) == {3, :test_argument_1}
-      assert Callable.example(:test_argument_2) == {3, :test_argument_2}
+      assert Callable.example(:a) == 1
+      assert Callable.example(:a) == {2, :a}
+      assert Callable.example(:a) == {3, :a}
+      assert Callable.example(:b) == {3, :b}
 
     end
   end

--- a/test/user/patch/raises_test.exs
+++ b/test/user/patch/raises_test.exs
@@ -56,5 +56,25 @@ defmodule Patch.Test.User.Patch.RaisesTest do
       assert Raises.example() == 2
       assert Raises.example() == 2
     end
+
+    test "can raise BadArityError" do
+      assert Raises.example() == :original
+
+      patch(Raises, :example, raises(BadArityError, function: fn -> :ok end, args: []))
+
+      assert_raise BadArityError, fn ->
+        Raises.example()
+      end
+    end
+
+    test "can raise FunctionClauseError" do
+      assert Raises.example() == :original
+
+      patch(Raises, :example, raises(FunctionClauseError, function: nil))
+
+      assert_raise FunctionClauseError, fn ->
+        Raises.example()
+      end
+    end
   end
 end


### PR DESCRIPTION
When patching a function with a function, the test author can now match
arguments.  If a function call occurs where the patched function does
not match the behavior is now to passthrough to the underlying module.

Resolves #30 