### PR TITLE
Improves the passthrough function behavior.

### DIFF
--- a/test/user/patch/callable_stack_test.exs
+++ b/test/user/patch/callable_stack_test.exs
@@ -80,5 +80,25 @@ defmodule Patch.Test.User.Patch.CallableStackTest do
       assert CallableStack.example(:a) == {:original, :a}
       assert CallableStack.example(:a, :b, :c) == {:original, :a, :b, :c}
     end
+
+    test "mock functions can raise FunctionClauseError" do
+      patch(CallableStack, :example, fn _ ->
+        raise FunctionClauseError
+      end)
+
+      assert_raise FunctionClauseError, fn ->
+        CallableStack.example(:a)
+      end
+    end
+
+    test "mock functions can raise BadArityError" do
+      patch(CallableStack, :example, fn _ ->
+        raise BadArityError, function: &String.trim/1, args: []
+      end)
+
+      assert_raise BadArityError, fn ->
+        CallableStack.example(:a)
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously if a mock function raised `BadArityError` or
`FunctionClauseError` because of a bad mock, Apply would consider this
to be a failed application.

This can cause confusion when a test author creates a broken mock.
Instead of reporting an error about the mock code, the original code is
called.

Apply has gained a new helper, `direct_exception?/2` which is used to
determine if the `BadArityError` or `FunctionClauseError` is being
raised by the application of the function or by the code in the
function.