### PR TITLE
Use erlef/setup-beam and bump versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,23 +59,23 @@ jobs:
             otp-version: 24.3
           - elixir-version: 1.13.4
             otp-version: 25.1
-          - elixir-version: 1.14.0
+          - elixir-version: 1.14.1
             otp-version: 23.3
-          - elixir-version: 1.14.0
+          - elixir-version: 1.14.1
             otp-version: 24.3
-          - elixir-version: 1.14.0
+          - elixir-version: 1.14.1
             otp-version: 25.1
-          
+
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: deps
         key: ${{ runner.os }}-${{ matrix.elixir-version }}-${{ matrix.otp-version}}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
Remove extra redirection. See https://github.com/erlef/setup-beam/issues/20

I've noticed there are no linting jobs (`mix format --check-formatted`) in the GitHub CI, let me know if you want me to add this for next PR. :smile: 