### PR TITLE
Support for targetless listeners

### DIFF
--- a/lib/patch/importer.ex
+++ b/lib/patch/importer.ex
@@ -148,6 +148,7 @@ defmodule Patch.Importer do
 
   defp delegate({:listen, symbol}) do
     quote do
+      defdelegate unquote(symbol)(tag), to: Patch, as: :listen
       defdelegate unquote(symbol)(tag, target), to: Patch, as: :listen
       defdelegate unquote(symbol)(tag, target, options), to: Patch, as: :listen
     end

--- a/test/support/user/inject/targetless.ex
+++ b/test/support/user/inject/targetless.ex
@@ -1,0 +1,33 @@
+defmodule Patch.Test.Support.User.Inject.Targetless do
+  @moduledoc """
+  In the scenarios this module is used in, target_pid is meant to be a pid that
+  is not defined at init but is expected to be loaded after initialization.
+
+  This module is used to test inject on part of the state that is nil
+  """
+
+  use GenServer
+
+  defstruct [:target_pid]
+
+  ## Client
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  def hello(pid) do
+    GenServer.call(pid, :hello)
+  end
+
+  ## Server
+
+  def init(:ok) do
+    {:ok, %__MODULE__{}}
+  end
+
+  def handle_call(:hello, _from, %__MODULE__{} = state) do
+    send(state.target_pid, :greetings)
+    {:reply, :ok, state}
+  end
+end

--- a/test/user/inject_test.exs
+++ b/test/user/inject_test.exs
@@ -3,6 +3,7 @@ defmodule Patch.Test.User.InjectTest do
   use Patch
 
   alias Patch.Test.Support.User.Inject.Caller
+  alias Patch.Test.Support.User.Inject.Targetless
 
   describe "inject/4" do
     test "Target listener can be injected into the Caller Process" do
@@ -17,6 +18,16 @@ defmodule Patch.Test.User.InjectTest do
 
       assert_receive {:target, {GenServer, :call, {:work, 7}, from}}
       assert_receive {:target, {GenServer, :reply, 70, ^from}}
+    end
+
+    test "Targetless listener can be injected into the Caller Process" do
+      {:ok, targetless_pid} = Targetless.start_link()
+
+      inject(:target, targetless_pid, [:target_pid])
+
+      assert Targetless.hello(targetless_pid) == :ok
+
+      assert_receive {:target, :greetings}
     end
   end
 end


### PR DESCRIPTION
 Listeners can also act as a complete substitute for a process.  This is useful in scenarios
  where one Process starts other Processes but starting those Processes is outside of the bounds
  of the test.  In those cases you can start a "targetless listener."