### PR TITLE
Fix deprecation warning on elixir 1.16

### DIFF
--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -413,7 +413,7 @@ defmodule Patch.Assertions do
   defmacro format_patterns(patterns) do
     patterns
     |> Macro.to_string()
-    |> String.slice(1..-2)
+    |> String.slice(1..-2//1)
   end
 
 end


### PR DESCRIPTION
This fixes deprecation warnings at runtime on elixir 1.16.

```
warning: negative steps are not supported in String.slice/2, pass 1..-2//1 instead
  (elixir 1.16.1) lib/string.ex:2369: String.slice/2
  (elixir 1.16.1) src/elixir_dispatch.erl:228: :elixir_dispatch.expand_macro_fun/7
  (elixir 1.16.1) src/elixir_dispatch.erl:215: :elixir_dispatch.expand_require/6
  (elixir 1.16.1) src/elixir_dispatch.erl:136: :elixir_dispatch.dispatch_require/7
  (elixir 1.16.1) src/elixir_expand.erl:599: :elixir_expand.expand_arg/3
  (elixir 1.16.1) src/elixir_expand.erl:615: :elixir_expand.mapfold/5
  (elixir 1.16.1) src/elixir_expand.erl:870: :elixir_expand.expand_remote/8
  (elixir 1.16.1) src/elixir_dispatch.erl:248: :elixir_dispatch.expand_quoted/7
  (elixir 1.16.1) src/elixir_expand.erl:599: :elixir_expand.expand_arg/3
  (elixir 1.16.1) src/elixir_bitstring.erl:146: :elixir_bitstring.expand_expr/5
  (elixir 1.16.1) src/elixir_bitstring.erl:34: :elixir_bitstring.expand/8
  (elixir 1.16.1) src/elixir_bitstring.erl:26: :elixir_bitstring.expand/5
  (elixir 1.16.1) src/elixir_expand.erl:10: :elixir_expand.expand/3
  (elixir 1.16.1) src/elixir_expand.erl:548: :elixir_expand.expand_block/5
  (elixir 1.16.1) src/elixir_expand.erl:46: :elixir_expand.expand/3
  (elixir 1.16.1) src/elixir_clauses.erl:45: :elixir_clauses.clause/6
  (elixir 1.16.1) src/elixir_clauses.erl:347: anonymous fn/7 in :elixir_clauses.expand_clauses_origin/6
  (stdlib 5.2) lists.erl:1706: :lists.mapfoldl_1/3
```