### PR TITLE
Silences unexpected message and fixes 1.16 deprecation

### DIFF
--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -67,7 +67,7 @@ defmodule Patch.Assertions do
   defmacro assert_called(call) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -121,7 +121,7 @@ defmodule Patch.Assertions do
   defmacro assert_called(call, count) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -183,7 +183,7 @@ defmodule Patch.Assertions do
   defmacro assert_called_once(call) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -280,7 +280,7 @@ defmodule Patch.Assertions do
   defmacro refute_called(call) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -330,7 +330,7 @@ defmodule Patch.Assertions do
   defmacro refute_called(call, count) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -381,7 +381,7 @@ defmodule Patch.Assertions do
   defmacro refute_called_once(call) do
     {module, function, patterns} = Macro.decompose_call(call)
 
-    quote do
+    quote generated: true do
       history =
         unquote(module)
         |> Patch.Mock.history()
@@ -413,7 +413,7 @@ defmodule Patch.Assertions do
   defmacro format_patterns(patterns) do
     patterns
     |> Macro.to_string()
-    |> String.slice(1..-2)
+    |> String.slice(1..-2//1)
   end
 
 end

--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -413,7 +413,7 @@ defmodule Patch.Assertions do
   defmacro format_patterns(patterns) do
     patterns
     |> Macro.to_string()
-    |> String.slice(1..-2//1)
+    |> String.slice(1..-2)
   end
 
 end

--- a/lib/patch/mock/server.ex
+++ b/lib/patch/mock/server.ex
@@ -190,6 +190,11 @@ defmodule Patch.Mock.Server do
     {:reply, :ok, do_register(state, name, value)}
   end
 
+  def handle_info(_, state) do
+    # To silence logs of unexpected messages received
+    {:noreply, state}
+  end
+
   def terminate(_, state) do
     do_restore(state)
   end


### PR DESCRIPTION
Hey, thanks for this great library!

My testing logs are getting flooded by messages like

```
Error: 16:14:39.389 [error] Patch.Mock.Server Patch.Mock.Server.For.Some.Module received unexpected message in handle_info/2: {:EXIT, #PID<0.11558.0>, :normal}
```

And also

```
warning: negative steps are not supported in String.slice/2, pass 1..-2//1 instead
  (elixir 1.16.2) lib/string.ex:2369: String.slice/2
  (elixir 1.16.2) elixir_dispatch.erl:228: :elixir_dispatch.expand_macro_fun/7
  (elixir 1.16.2) elixir_dispatch.erl:215: :elixir_dispatch.expand_require/6
  (elixir 1.16.2) elixir_dispatch.erl:136: :elixir_dispatch.dispatch_require/7
  (elixir 1.16.2) elixir_expand.erl:599: :elixir_expand.expand_arg/3
  (elixir 1.16.2) elixir_expand.erl:615: :elixir_expand.mapfold/5
  (elixir 1.16.2) elixir_expand.erl:870: :elixir_expand.expand_remote/8
  (elixir 1.16.2) elixir_dispatch.erl:248: :elixir_dispatch.expand_quoted/7
  (elixir 1.16.2) elixir_expand.erl:599: :elixir_expand.expand_arg/3
  (elixir 1.16.2) elixir_bitstring.erl:146: :elixir_bitstring.expand_expr/5
  (elixir 1.16.2) elixir_bitstring.erl:34: :elixir_bitstring.expand/8
  (elixir 1.16.2) elixir_bitstring.erl:26: :elixir_bitstring.expand/5
  (elixir 1.16.2) elixir_expand.erl:10: :elixir_expand.expand/3
  (elixir 1.16.2) elixir_expand.erl:548: :elixir_expand.expand_block/5
  (elixir 1.16.2) elixir_expand.erl:46: :elixir_expand.expand/3
  (elixir 1.16.2) elixir_clauses.erl:45: :elixir_clauses.clause/6
  (elixir 1.16.2) elixir_clauses.erl:347: anonymous fn/7 in :elixir_clauses.expand_clauses_origin/6
  (stdlib 5.2.1) lists.erl:1706: :lists.mapfoldl_1/3
```

This PR overrides default handle_info into a handler which does nothing. And adds `generated` tag to all macros, plus fixes the deprecation itself

PS: Minor version bump and publish would be heavily appreciated.