### PR TITLE
Fix a warning in Elixir 1.16

### DIFF
--- a/lib/patch/assertions.ex
+++ b/lib/patch/assertions.ex
@@ -411,9 +411,8 @@ defmodule Patch.Assertions do
   """
   @spec format_patterns(patterns :: [term()]) :: String.t()
   defmacro format_patterns(patterns) do
-    patterns
-    |> Macro.to_string()
-    |> String.slice(1..-2)
+    string = Macro.to_string(patterns)
+    stop = max(String.length(string) - 2, 0)
+    String.slice(string, 1, stop)
   end
-
 end


### PR DESCRIPTION
`1..-2` has an implicit `-1` step which is unused by String.slice but which generates a warning in Elixir 1.16

Elixir 1.16 suggests replacing this with `1..-2//1` but this syntax was introduced in 1.12 and would break any user of the library on older versions of Elixir.

This bugfix switches to `String.slice/3` which is available on all supported versions.