### PR TITLE
Handle undefined modules when patching and raise UndefinedFunctionError

### DIFF
--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -489,7 +489,14 @@ defmodule Patch do
   """
   @spec patch(module :: module(), function :: atom(), value :: Value.t()) :: Value.t()
   def patch(module, function, %value_module{} = value) when is_value(value_module) do
-    {:ok, _} = Patch.Mock.module(module)
+    case Patch.Mock.module(module) do
+      {:ok, _} ->
+        :ok
+
+      {:error, :nofile} ->
+        raise %UndefinedFunctionError{module: module, function: function, arity: 0}
+    end
+
     :ok = Patch.Mock.register(module, function, value)
     value
   end

--- a/test/user/patch/unknown_module_test.exs
+++ b/test/user/patch/unknown_module_test.exs
@@ -1,0 +1,16 @@
+defmodule Patch.Test.User.Patch.UnknownModuleTest do
+  use ExUnit.Case
+  use Patch
+
+  describe "patching unknown module" do
+    test "results in an exception" do
+      assert_raise UndefinedFunctionError, fn ->
+        patch(NoSuchModule, :function_that_does_not_exist, :patched)
+      end
+
+      assert_raise UndefinedFunctionError, fn ->
+        patch(NoSuchModule, :function_that_does_not_exist, fn _x -> 42 end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have noticed that trying to patch non-existing modules, results in an error, that may be quite difficult to understand. 
The following code
```Elixir
patch(NoSuchModule, :function_that_does_not_exist, fn _x -> 42 end)
```
will result in the following error
```Elixir
     ** (MatchError) no match of right hand side value: {:error, :nofile}
     code: patch(NoSuchModule, :function_that_does_not_exist, :patched)
     stacktrace:
       (patch 0.13.1) lib/patch.ex:492: Patch.patch/3
       (patch 0.13.1) lib/patch.ex:514: Patch.patch/3
       test/user/patch/unknown_module_test.exs:8: (test)
```
The first couple of times I saw this, I had absolutely no clue about what was going on. Only by looking into the `patch` source code, it became apparent, that I was doing something wrong.

This PR adds a simple check that handles the `{:error, :nofile}` case, and emits an error message that should be easier to understand:
```Elixir
     ** (UndefinedFunctionError) function NoSuchModule.function_that_does_not_exist/0 is undefined (module NoSuchModule is not available)
     code: patch(NoSuchModule, :function_that_does_not_exist, :patched)
     stacktrace:
       (patch 0.13.1) lib/patch.ex:497: Patch.patch/3
       (patch 0.13.1) lib/patch.ex:514: Patch.patch/3
       test/user/patch/unknown_module_test.exs:8: (test)
```