### PR TITLE
Move where mock execution happens

### DIFF
--- a/test/support/user/patch/execution_context.ex
+++ b/test/support/user/patch/execution_context.ex
@@ -1,0 +1,5 @@
+defmodule Patch.Test.Support.User.Patch.ExecutionContext do
+  def example() do
+    :original
+  end
+end

--- a/test/user/patch/execution_context_test.exs
+++ b/test/user/patch/execution_context_test.exs
@@ -1,0 +1,16 @@
+defmodule Patch.Test.User.Patch.ExecutionContextTest do
+  use ExUnit.Case
+  use Patch
+
+  alias Patch.Test.Support.User.Patch.ExecutionContext
+
+  describe "execution context" do
+    test "patch executes the mock function in the caller's execution context" do
+      assert ExecutionContext.example() == :original
+
+      patch(ExecutionContext, :example, fn -> self() end)
+
+      assert ExecutionContext.example() == self()
+    end
+  end
+end


### PR DESCRIPTION
- Previously, mocks were executed in the Patch.Mock.Server context. 
- With this change, mocks are executed in the callers context.

When providing a mock function it is a reasonable expectation that any function that cares about the current process would get the caller's process and not the Patch.Mock.Server.