### PR TITLE
Adjust patch version on cheatsheet

### DIFF
--- a/pages/cheatsheet.cheatmd
+++ b/pages/cheatsheet.cheatmd
@@ -13,7 +13,7 @@ In the `deps/0` function in the mix.exs file add a line for Patch.
 ```elixir
 def deps do
   [
-    {:patch, "~> 0.12.0", only: [:test]}
+    {:patch, "~> 0.14.0", only: [:test]}
   ]
 end
 ```


### PR DESCRIPTION
The current cheatsheet contains the old version of patch:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/f7cbe189-35cb-4a78-9d51-c410ae8f2e03">

this PR fixes that to the current version.