### PR TITLE
Local calls can be patched in string interpolations

### DIFF
--- a/lib/patch/mock/code/transforms/remote.ex
+++ b/lib/patch/mock/code/transforms/remote.ex
@@ -54,6 +54,14 @@ defmodule Patch.Mock.Code.Transforms.Remote do
     end
   end
 
+  defp expression({:bin, anno, body}, module, exports) do
+    {:bin, anno, expressions(body, module, exports)}
+  end
+
+  defp expression({:bin_element, anno, body, size, types}, module, exports) do
+    {:bin_element, anno, expression(body, module, exports), size, types}
+  end
+
   defp expression({:block, anno, body}, module, exports) do
     {:block, anno, expressions(body, module, exports)}
   end

--- a/test/support/user/patch/local_call.ex
+++ b/test/support/user/patch/local_call.ex
@@ -3,6 +3,10 @@ defmodule Patch.Test.Support.User.Patch.LocalCall do
     {:original, public_function(a)}
   end
 
+  def public_caller_string_interpolation(a) do
+    {:original, "#{inspect(public_function(a))}"}
+  end
+
   def public_function(a) do
     {:public, a}
   end
@@ -17,6 +21,10 @@ defmodule Patch.Test.Support.User.Patch.LocalCall do
 
   def private_caller(a) do
     {:original, private_function(a)}
+  end
+
+  def private_caller_string_interpolation(a) do
+    {:original, "#{inspect(private_function(a))}"}
   end
 
   ## Private

--- a/test/user/patch/local_call_test.exs
+++ b/test/user/patch/local_call_test.exs
@@ -13,6 +13,14 @@ defmodule Patch.Test.User.Patch.LocalCallTest do
       assert LocalCall.public_caller(:test_argument) == {:original, :patched}
     end
 
+    test "can be patched in a string interpolation" do
+      assert LocalCall.public_caller_string_interpolation(:test_argument) == {:original, "{:public, :test_argument}"}
+
+      patch(LocalCall, :public_function, :patched)
+
+      assert LocalCall.public_caller_string_interpolation(:test_argument) == {:original, ":patched"}
+    end
+
     test "can be assert_called" do
       assert LocalCall.public_caller(:test_argument) == {:original, {:public, :test_argument}}
 
@@ -39,6 +47,14 @@ defmodule Patch.Test.User.Patch.LocalCallTest do
       patch(LocalCall, :private_function, :patched)
 
       assert LocalCall.private_caller(:test_argument) == {:original, :patched}
+    end
+
+    test "can be patched in a string interpolation" do
+      assert LocalCall.private_caller_string_interpolation(:test_argument) == {:original, "{:private, :test_argument}"}
+
+      patch(LocalCall, :private_function, :patched)
+
+      assert LocalCall.private_caller_string_interpolation(:test_argument) == {:original, ":patched"}
     end
 
     test "can be assert_called" do


### PR DESCRIPTION
Fixes #78

I wasn't 100% on if the test fit in the user tests, but given the README calls out regression tests, I felt it made the most sense.