### PR TITLE
Clarifies the matching behavior of assert_called 

### DIFF
--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -107,6 +107,22 @@ defmodule Patch do
   assert_called Example.function(4, 5, 6)   # fails
   assert_called Example.function(4, _, 6)   # fails
   ```
+
+  If a pattern would match multiple calls, the latest call will be bound.
+
+  ```elixir
+  patch(Example, :function, :patch)
+
+  Example.function(1, 2, 3)
+
+  assert_called Example.function(a, b, c)   # passes
+  IO.inspect([a, b, c])                     # prints "[1, 2, 3]"
+
+  Example.function(4, 5, 6)
+  Example.function(7, 8, 9)
+
+  assert_called Example.function(a, b, c)   # passes
+  IO.inspect([a, b, c])                     # prints "[7, 8, 9]"
   """
   @spec assert_called(Macro.t()) :: Macro.t()
   defmacro assert_called(call) do

--- a/test/user/assert_called_test.exs
+++ b/test/user/assert_called_test.exs
@@ -115,6 +115,30 @@ defmodule Patch.Test.User.AssertCalledTest do
       assert y == 2
     end
 
+    test "when multiple calls match the latest is returned" do
+      patch(AssertCalled, :example, :patched)
+
+      assert AssertCalled.example(1, 2) == :patched
+
+      assert_called AssertCalled.example(a, b)
+      assert a == 1
+      assert b == 2
+
+      assert AssertCalled.example(3, 4) == :patched
+
+      assert_called AssertCalled.example(a, b)
+      assert a == 3
+      assert b == 4
+
+
+      assert AssertCalled.example(5, 6) == :patched
+      assert AssertCalled.example(7, 8) == :patched
+
+      assert_called AssertCalled.example(a, b)
+      assert a == 7
+      assert b == 8
+    end
+
     test "exception formatting with no calls" do
       patch(AssertCalled, :example, :patched)
 


### PR DESCRIPTION
In the presence of multiple matching calls, assert_called will bind to the latest call.