### PR TITLE
Fixes missed export bug.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,42 +13,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir-version: 1.9.4
-            otp-version: 20.3
-          - elixir-version: 1.9.4
-            otp-version: 21.3
-          - elixir-version: 1.9.4
-            otp-version: 22.3
-          - elixir-version: 1.10.4
-            otp-version: 21.3
-          - elixir-version: 1.10.4
-            otp-version: 22.3
-          - elixir-version: 1.10.4
-            otp-version: 23.3
-          - elixir-version: 1.11.4
-            otp-version: 21.3
-          - elixir-version: 1.11.4
-            otp-version: 22.3
-          - elixir-version: 1.11.4
-            otp-version: 23.3
           - elixir-version: 1.11.4
             otp-version: 24.3
           - elixir-version: 1.12.3
-            otp-version: 22.3
-          - elixir-version: 1.12.3
-            otp-version: 23.3
-          - elixir-version: 1.12.3
             otp-version: 24.3
-          - elixir-version: 1.13.4
-            otp-version: 22.3
-          - elixir-version: 1.13.4
-            otp-version: 23.3
           - elixir-version: 1.13.4
             otp-version: 24.3
           - elixir-version: 1.13.4
             otp-version: 25.3
-          - elixir-version: 1.14.5
-            otp-version: 23.3
           - elixir-version: 1.14.5
             otp-version: 24.3
           - elixir-version: 1.14.5
@@ -72,11 +44,13 @@ jobs:
           - elixir-version: 1.17.3
             otp-version: 26.2
           - elixir-version: 1.17.3
-            otp-version: 27.2
-          - elixir-version: 1.18.1
+            otp-version: 27.3
+          - elixir-version: 1.18.4
             otp-version: 26.2
-          - elixir-version: 1.18.1
-            otp-version: 27.2
+          - elixir-version: 1.18.4
+            otp-version: 27.3
+          - elixir-version: 1.18.4
+            otp-version: 28.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -77,7 +77,6 @@ jobs:
             otp-version: 26.2
           - elixir-version: 1.18.1
             otp-version: 27.2
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
             otp-version: 26.2
           - elixir-version: 1.18.4
             otp-version: 27.3
-          - elixir-version: 1.18.4
-            otp-version: 28.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/README.md
+++ b/README.md
@@ -164,16 +164,13 @@ For a guided tour and deep dive of Patch, see the [Guide Book](https://hexdocs.p
 
 Tests automatically run against a matrix of OTP and Elixir Versions, see the [ci.yml](https://github.com/ihumanable/patch/tree/master/.github/workflows/ci.yml) for details.
 
-| OTP \ Elixir | 1.9  | 1.10 | 1.11 | 1.12 | 1.13 | 1.14 | 1.15 | 1.16 | 1.17 | 1.18 |
-|:------------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
-| 20           | ✅   | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  |
-| 21           | ✅   | ✅   | ✅   | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  | N/A  |
-| 22           | ✅   | ✅   | ✅   | ✅   | ✅   | N/A  | N/A  | N/A  | N/A  | N/A  |
-| 23           | N/A  | ✅   | ✅   | ✅   | ✅   | ✅   | N/A  | N/A  | N/A  | N/A  |
-| 24           | N/A  | N/A  | ✅   | ✅   | ✅   | ✅   | ✅   | N/A  | N/A  | N/A  |
-| 25           | N/A  | N/A  | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   | ?    |
-| 26           | N/A  | N/A  | N/A   | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   |
-| 27           | N/A  | N/A  | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | ✅   | ✅   |
+| OTP \ Elixir | 1.11 | 1.12 | 1.13 | 1.14 | 1.15 | 1.16 | 1.17 | 1.18 |
+|:------------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+| 24           | ✅   | ✅   | ✅   | ✅   | ✅   | N/A  | N/A  | N/A  |
+| 25           | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   | N/A    |
+| 26           | N/A   | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   |
+| 27           | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | ✅   | ✅   |
+| 28           | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | ✅   |
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Tests automatically run against a matrix of OTP and Elixir Versions, see the [ci
 | 25           | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   | N/A    |
 | 26           | N/A   | N/A   | N/A   | ✅   | ✅   | ✅   | ✅   | ✅   |
 | 27           | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | ✅   | ✅   |
-| 28           | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | N/A   | ✅   |
 
 ## Limitations
 

--- a/lib/patch/mock/code/queries/exports.ex
+++ b/lib/patch/mock/code/queries/exports.ex
@@ -9,7 +9,8 @@ defmodule Patch.Mock.Code.Queries.Exports do
     abstract_forms
     |> Enum.filter(&match?({:attribute, _, :export, _}, &1))
     |> Enum.reduce([], fn {_, _, _, exports}, acc ->
-      Keyword.merge(acc, exports)
+      [exports | acc]
     end)
+    |> List.flatten()
   end
 end

--- a/test/unit/patch/mock/code/queries/exports_test.exs
+++ b/test/unit/patch/mock/code/queries/exports_test.exs
@@ -1,0 +1,23 @@
+defmodule Patch.Test.Unit.Patch.Mock.Code.Queries.ExportsTest do
+  use ExUnit.Case
+
+  alias Patch.Mock.Code.Queries.Exports
+
+  describe "query/1" do
+    test "handles functions with multiple arities declared across multiple exports" do
+      forms = [
+        {:attribute, 1, :export, [a: 1]},
+        {:attribute, 1, :export, [a: 2]}
+      ]
+
+      expected = Enum.sort([a: 1, a: 2])
+
+      actual =
+        forms
+        |> Exports.query()
+        |> Enum.sort()
+
+      assert expected == actual
+    end
+  end
+end


### PR DESCRIPTION
When the same function is exported with multiple arities in multiple different export attributes the old code would merge them so only the last arity would be kept