### PR TITLE
bugfix: local function name will change for inline compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 patch-*.tar
+.tool-versions
 

--- a/lib/patch/apply.ex
+++ b/lib/patch/apply.ex
@@ -43,10 +43,10 @@ defmodule Patch.Apply do
 
   defp check_function_name(function_info, error) do
     # for Erlang inline will change the local function name
-    if function_info[:type] == :local do
-      true
-    else
-      function_info[:name] == error.function
+    cond do
+      function_info[:name] == error.function -> true
+      function_info[:type] == :local -> true
+      true -> false
     end
   end
 end

--- a/lib/patch/apply.ex
+++ b/lib/patch/apply.ex
@@ -38,6 +38,15 @@ defmodule Patch.Apply do
 
   defp direct_exception?(function, %FunctionClauseError{} = error) do
     info = Function.info(function)
-    info[:arity] == error.arity and info[:name] == error.function
+    info[:arity] == error.arity and info[:module] == error.module and check_function_name(info, error)
+  end
+
+  defp check_function_name(function_info, error) do
+    # for Erlang inline will change the local function name
+    if function_info[:type] == :local do
+      true
+    else
+      function_info[:name] == error.function
+    end
   end
 end


### PR DESCRIPTION


erlang: OTP28.4
elixir: 1.19.5

```elixir
[(patch 0.16.0) lib/patch/apply.ex:42: Patch.Apply.direct_exception?/2]
binding() #=> [
  error: %FunctionClauseError{
    module: GangplankTest.ALIGAMES.Players,
    function: :"-test cancel account/1-inlined-4-", # inline compile will change the function name
    arity: 4,
    kind: nil,
    args: nil,
    clauses: nil
  },
  function: #Function<11.48830410/4 in GangplankTest.ALIGAMES.Players."test cancel account"/1>,
  info: [
    pid: #PID<0.0.0>,
    module: GangplankTest.ALIGAMES.Players,
    new_index: 11,
    new_uniq: <<93, 34, 249, 64, 161, 244, 158, 193, 228, 18, 82, 59, 241, 154,
      115, 235>>,
    index: 11,
    uniq: 48830410,
    name: :"-test cancel account/1-fun-6-", # then origin name
    arity: 4,
    env: ["https://account.flysdk.cn/ieu/account.status.query?ver=1.0&df=json",
     #Function<7.48830410/1 in GangplankTest.ALIGAMES.Players."test cancel account"/1>],
    type: :local
  ]
]
```

I am upgrading the Elixir version for my project and found that OTP changes the names of anonymous functions during inlining. I think it would be appropriate to relax the validation for these functions.

btw. great job! this lib helps a lot for me. 